### PR TITLE
Update experiment-management-api-experiments.md

### DIFF
--- a/content/collections/experiment-apis/en/experiment-management-api-experiments.md
+++ b/content/collections/experiment-apis/en/experiment-management-api-experiments.md
@@ -979,6 +979,10 @@ curl --request DELETE \
 
 ## Edit
 
+{{partial:admonition type='note'}}
+We do not currently support editing web experiments.
+{{/partial:admonition}}
+
 ```bash
 PATCH https://experiment.amplitude.com/api/1/experiments/{id}
 ```
@@ -1097,7 +1101,7 @@ curl --request PATCH \
 POST https://experiment.amplitude.com/api/1/experiments
 ```
 
-Create a new experiment.
+Create a new feature experiment.
 
 ### Request body
 

--- a/content/collections/experiment-apis/en/experiment-management-api-experiments.md
+++ b/content/collections/experiment-apis/en/experiment-management-api-experiments.md
@@ -980,7 +980,7 @@ curl --request DELETE \
 ## Edit
 
 {{partial:admonition type='note'}}
-We do not currently support editing web experiments. If you try to edit a web experiment, you will get a 501 error.
+Web Experimentation doesn't support the editing of experiments. Attempts to edit a web experiment return a `501` error.
 {{/partial:admonition}}
 
 ```bash

--- a/content/collections/experiment-apis/en/experiment-management-api-experiments.md
+++ b/content/collections/experiment-apis/en/experiment-management-api-experiments.md
@@ -980,7 +980,7 @@ curl --request DELETE \
 ## Edit
 
 {{partial:admonition type='note'}}
-We do not currently support editing web experiments.
+We do not currently support editing web experiments. If you try to edit a web experiment, you will get a 501 error.
 {{/partial:admonition}}
 
 ```bash


### PR DESCRIPTION
We only support creating feature experiments and not web experiments. For editing experiments, we only support editing feature experiments.

cc @hthr-lee just wanted to double check, this https://github.com/amplitude/javascript/blob/master/server/packages/skylab-backend/src/management-api/routes/apply-middleware.ts#L32 is only blocking this route `PATCH https://experiment.amplitude.com/api/1/experiments/{id}` right?