### PR TITLE
fix Experiment cohort sync config table

### DIFF
--- a/content/collections/experiment-sdks/en/experiment-go.md
+++ b/content/collections/experiment-sdks/en/experiment-go.md
@@ -231,14 +231,13 @@ If you're using Amplitude's EU data center, configure the `ServerZone` option on
 
 **CohortSyncConfig**
 
-| <div class="big-column">Name</div> | Description | Default Value |
-|------------------------------------| --- | --- |
-| `ApiKey`                           | The analytics API key and NOT the experiment deployment key | *required* |
-| `SecretKey`                        | The analytics secret key | *required* |
-| `MaxCohortSize`                    | The maximum size of cohort that the SDK will download. Cohorts larger than this size won't download. | `2147483647` |
-| `CohortPollingIntervalMillis`      | The interval, in milliseconds, to poll Amplitude for cohort updates (60000 minimum). | `60000` |
-| `CohortServerUrl`                  | The cohort server endpoint from which to fetch cohort data. For hitting the EU data center, set `ServerZone` to `EUServerZone`.
-Setting this value will override `ServerZone` defaults. | `https://cohort-v2.lab.amplitude.com` |
+| <div class="big-column">Name</div> | Description                                                                                                                                                                             | Default Value |
+|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| --- |
+| `ApiKey`                           | The analytics API key and NOT the experiment deployment key                                                                                                                             | *required* |
+| `SecretKey`                        | The analytics secret key                                                                                                                                                                | *required* |
+| `MaxCohortSize`                    | The maximum size of cohort that the SDK will download. Cohorts larger than this size won't download.                                                                                    | `2147483647` |
+| `CohortPollingIntervalMillis`      | The interval, in milliseconds, to poll Amplitude for cohort updates (60000 minimum).                                                                                                    | `60000` |
+| `CohortServerUrl`                  | The cohort server endpoint from which to fetch cohort data. For hitting the EU data center, set `ServerZone` to `EUServerZone`. Setting this value will override `ServerZone` defaults. | `https://cohort-v2.lab.amplitude.com` |
 
 ### Start
 

--- a/content/collections/experiment-sdks/en/experiment-jvm.md
+++ b/content/collections/experiment-sdks/en/experiment-jvm.md
@@ -172,14 +172,13 @@ If you're using Amplitude's EU data center, configure the `serverZone` option on
 
 **CohortSyncConfig**
 
-| <div class="big-column">Name</div> | Description                                                                                          | Default Value |
-| --- |------------------------------------------------------------------------------------------------------| --- |
-| `apiKey` | The analytics API key and NOT the experiment deployment key                                          | *required* |
-| `secretKey` | The analytics secret key                                                                             | *required* |
-| `maxCohortSize` | The maximum size of cohort that the SDK will download. Cohorts larger than this size won't download. | `2147483647` |
-| `cohortPollingIntervalMillis` | The interval, in milliseconds, to poll Amplitude for cohort updates (60000 minimum).                 | `60000` |
-| `cohortServerUrl`                  | The cohort server endpoint from which to fetch cohort data. For hitting the EU data center, set `serverZone` to `ServerZone.EU`.
-Setting this value will override `serverZone` defaults.                                                     | `https://cohort-v2.lab.amplitude.com` |
+| <div class="big-column">Name</div> | Description                                                                                                                                                                              | Default Value |
+| --- |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| --- |
+| `apiKey` | The analytics API key and NOT the experiment deployment key                                                                                                                              | *required* |
+| `secretKey` | The analytics secret key                                                                                                                                                                 | *required* |
+| `maxCohortSize` | The maximum size of cohort that the SDK will download. Cohorts larger than this size won't download.                                                                                     | `2147483647` |
+| `cohortPollingIntervalMillis` | The interval, in milliseconds, to poll Amplitude for cohort updates (60000 minimum).                                                                                                     | `60000` |
+| `cohortServerUrl`                  | The cohort server endpoint from which to fetch cohort data. For hitting the EU data center, set `serverZone` to `ServerZone.EU`. Setting this value will override `serverZone` defaults. | `https://cohort-v2.lab.amplitude.com` |
 
 ### Fetch
 

--- a/content/collections/experiment-sdks/en/experiment-node-js.md
+++ b/content/collections/experiment-sdks/en/experiment-node-js.md
@@ -263,14 +263,13 @@ If you're using Amplitude's EU data center, configure the `serverZone` option on
 
 **CohortSyncConfig**
 
-| <div class="big-column">Name</div> | Description                                                                                                  | Default Value |
-|------------------------------------|--------------------------------------------------------------------------------------------------------------| --- |
-| `apiKey`                           | The analytics API key and NOT the experiment deployment key                                                  | *required* |
-| `secretKey`                        | The analytics secret key                                                                                     | *required* |
-| `maxCohortSize`                    | The maximum size of cohort that the SDK will download. Cohorts larger than this size will not be downloaded. | `2147483647` |
-| `cohortPollingIntervalMillis`      | The interval, in milliseconds, to poll Amplitude for cohort updates (60000 minimum).                         | `60000` |
-| `cohortServerUrl`                  | The cohort server endpoint from which to fetch cohort data. For hitting the EU data center, set `serverZone` to `eu`.
-Setting this value will override `serverZone` defaults.                                                             | `https://cohort-v2.lab.amplitude.com` |
+| <div class="big-column">Name</div> | Description                                                                                                                                                                   | Default Value |
+|------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| --- |
+| `apiKey`                           | The analytics API key and NOT the experiment deployment key                                                                                                                   | *required* |
+| `secretKey`                        | The analytics secret key                                                                                                                                                      | *required* |
+| `maxCohortSize`                    | The maximum size of cohort that the SDK will download. Cohorts larger than this size will not be downloaded.                                                                  | `2147483647` |
+| `cohortPollingIntervalMillis`      | The interval, in milliseconds, to poll Amplitude for cohort updates (60000 minimum).                                                                                          | `60000` |
+| `cohortServerUrl`                  | The cohort server endpoint from which to fetch cohort data. For hitting the EU data center, set `serverZone` to `eu`. Setting this value will override `serverZone` defaults. | `https://cohort-v2.lab.amplitude.com` |
 
 ### Start
 

--- a/content/collections/experiment-sdks/en/experiment-python.md
+++ b/content/collections/experiment-sdks/en/experiment-python.md
@@ -275,14 +275,13 @@ If you're using Amplitude's EU data center, configure the `server_zone` option o
 
 **CohortSyncConfig**
 
-| <div class="big-column">Name</div> | Description | Default Value |
-|------------------------------------| --- | --- |
-| `api_key`                          | The analytics API key and NOT the experiment deployment key | *required* |
-| `secret_key`                       | The analytics secret key | *required* |
-| `max_cohort_size`                  | The maximum size of cohort that the SDK will download. Cohorts larger than this size will not be downloaded. | `2147483647` |
-| `cohort_polling_interval_millis`   | The interval, in milliseconds, to poll Amplitude for cohort updates (60000 minimum). | `60000` |
-| `cohort_server_url`                | The cohort server endpoint from which to fetch cohort data. For hitting the EU data center, set `server_zone` to `ServerZone.EU`.
-Setting this value will override `server_zone` defaults. | `https://cohort-v2.lab.amplitude.com` |
+| <div class="big-column">Name</div> | Description                                                                                                                                                                                | Default Value |
+|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| --- |
+| `api_key`                          | The analytics API key and NOT the experiment deployment key                                                                                                                                | *required* |
+| `secret_key`                       | The analytics secret key                                                                                                                                                                   | *required* |
+| `max_cohort_size`                  | The maximum size of cohort that the SDK will download. Cohorts larger than this size will not be downloaded.                                                                               | `2147483647` |
+| `cohort_polling_interval_millis`   | The interval, in milliseconds, to poll Amplitude for cohort updates (60000 minimum).                                                                                                       | `60000` |
+| `cohort_server_url`                | The cohort server endpoint from which to fetch cohort data. For hitting the EU data center, set `server_zone` to `ServerZone.EU`. Setting this value will override `server_zone` defaults. | `https://cohort-v2.lab.amplitude.com` |
 
 ### Start
 

--- a/content/collections/experiment-sdks/en/experiment-ruby.md
+++ b/content/collections/experiment-sdks/en/experiment-ruby.md
@@ -327,14 +327,13 @@ If you're using Amplitude's EU data center, configure the `server_zone` option o
 
 **CohortSyncConfig**
 
-| <div class="big-column">Name</div> | Description | Default Value |
-| --- | --- | --- |
-| `api_key` | The analytics API key and NOT the experiment deployment key | *required* |
-| `secret_key` | The analytics secret key | *required* |
-| `max_cohort_size` | The maximum size of cohort that the SDK will download. Cohorts larger than this size will not be downloaded. | `2147483647` |
-| `cohort_polling_interval_millis` | The interval, in milliseconds, to poll Amplitude for cohort updates (60000 minimum). | `60000` |
-| `cohort_server_url`                | The cohort server endpoint from which to fetch cohort data. For hitting the EU data center, set `server_zone` to `EU`.
-Setting this value will override `server_zone` defaults. | `https://cohort-v2.lab.amplitude.com` |
+| <div class="big-column">Name</div> | Description                                                                                                                                                                     | Default Value |
+| --- |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| --- |
+| `api_key` | The analytics API key and NOT the experiment deployment key                                                                                                                     | *required* |
+| `secret_key` | The analytics secret key                                                                                                                                                        | *required* |
+| `max_cohort_size` | The maximum size of cohort that the SDK will download. Cohorts larger than this size will not be downloaded.                                                                    | `2147483647` |
+| `cohort_polling_interval_millis` | The interval, in milliseconds, to poll Amplitude for cohort updates (60000 minimum).                                                                                            | `60000` |
+| `cohort_server_url`                | The cohort server endpoint from which to fetch cohort data. For hitting the EU data center, set `server_zone` to `EU`. Setting this value will override `server_zone` defaults. | `https://cohort-v2.lab.amplitude.com` |
 
 ### Start
 


### PR DESCRIPTION
Fix issue due to extra newline in description:

<img width="940" alt="image" src="https://github.com/user-attachments/assets/444e900f-5abc-4af1-b0e2-68b11713b536">