### PR TITLE
fix: browser sdk init callback should accept no param

### DIFF
--- a/content/collections/browser_sdk/en/browser-sdk-1.md
+++ b/content/collections/browser_sdk/en/browser-sdk-1.md
@@ -657,7 +657,7 @@ All asynchronous APIs are optionally awaitable through a Promise interface. This
 {{partial:tabs tabs="Promise, async/await"}}
 {{partial:tab name="Promise"}}
 ```ts
-amplitude.init("apikey", "12321.com").promise.then(function(result) { 
+amplitude.init("apikey", "12321.com").promise.then(function() { 
   // init callback
 })
 

--- a/content/collections/browser_sdk/en/browser-sdk-2.md
+++ b/content/collections/browser_sdk/en/browser-sdk-2.md
@@ -895,7 +895,7 @@ All asynchronous APIs are optionally awaitable through a Promise interface. This
 {{partial:tabs tabs="Promise, async/await"}}
 {{partial:tab name="Promise"}}
 ```ts
-amplitude.init("apikey", "12321.com").promise.then(function(result) { 
+amplitude.init("apikey", "12321.com").promise.then(function() { 
  // init callback
 })
 


### PR DESCRIPTION
Source: https://discourse.amplitude.com/t/browser-sdk-2-0-init-callback-possibility/11035/10

`init()` returns `Promise<void>`.