### PR TITLE
Update experiment-management-api-experiments.md

### DIFF
--- a/content/collections/experiment-apis/en/experiment-management-api-experiments.md
+++ b/content/collections/experiment-apis/en/experiment-management-api-experiments.md
@@ -1108,7 +1108,7 @@ Create a new feature experiment.
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
 |`projectId`| Required | string | The project's ID. |
-|`key`| Required | string | The experiment key. |
+|`key`| Required | string | The flag key. |
 |`name`| Optional | string | The experiment name. |
 |`description`| Optional | string | Description for the experiment.|
 |`variants`| Optional | object array | Array of [`variants`](#variants). |


### PR DESCRIPTION
make it clear that `key` does not mean the experiment key https://amplitude.com/docs/feature-experiment/troubleshooting/restart-an-experiment#experiment-key that is for restarting an experiment