### PR TITLE
AMP-118975 sendBeacon() warning

### DIFF
--- a/content/collections/browser_sdk/en/browser-sdk-2.md
+++ b/content/collections/browser_sdk/en/browser-sdk-2.md
@@ -1130,7 +1130,7 @@ Unlike standard network requests, sendBeacon sends events in the background, eve
 `sendBeacon` sends events in the background. As a result, events dispatched by `sendBeacon` don't return server responses. Keep the following in mind if you use `sendBeacon`:
 
 1. Requests are not retried, including failed requests with 4xx or 5xx responses, so events may be lost.
-2. Event order cannot be guaranteed, as `sendBeacon` may send events in parallel. This can lead to some UTM properties not being set, e.g. for session start events. In contrast, while using `fetch`, the SDK waits for responses before proceeding, guaranteeing event order.
+2. Event order cannot be guaranteed, as `sendBeacon` may send events in parallel. This can lead to some UTM properties not being set, for example for session start events. In contrast, while using `fetch`, the SDK waits for responses before proceeding, guaranteeing event order.
 {{/partial:admonition}}
 
 #### Set the transport to use sendBeacon for all events

--- a/content/collections/browser_sdk/en/browser-sdk-2.md
+++ b/content/collections/browser_sdk/en/browser-sdk-2.md
@@ -1127,7 +1127,10 @@ amplitude.track("event")
 Unlike standard network requests, sendBeacon sends events in the background, even if the user closes the browser or leaves the page.
 
 {{partial:admonition type="warning" heading=""}}
-Because `sendBeacon` sends events in the background, events dispatched from `sendBeacon` don't return a server response and can't be retried when they encounter failures like 4xx or 5xx errors. You can address these retry issues by sending one event/request, but this could increase the network load and the likelihood of throttling.
+Because `sendBeacon` sends events in the background, events dispatched from `sendBeacon` don't return a server response. This leads to two important caveats, so be cautious when using `sendBeacon` and keep these in mind:
+
+1. You might end up losing events becase there is no retry, even when 4xx or 5xx responses occur.
+2. Unlike `fetch`, which returns a response that the SDK waits for before sending another request to guarantee event order received by the server, `sendBeacon` may send events in parallel, potentially resulting in the server receiving events out of order. This can lead to some UTM properties not being set for session start events for example.
 {{/partial:admonition}}
 
 #### Set the transport to use sendBeacon for all events

--- a/content/collections/browser_sdk/en/browser-sdk-2.md
+++ b/content/collections/browser_sdk/en/browser-sdk-2.md
@@ -1129,7 +1129,7 @@ Unlike standard network requests, sendBeacon sends events in the background, eve
 {{partial:admonition type="warning" heading=""}}
 `sendBeacon` sends events in the background. As a result, events `sendBeacon` dispatches don't return a server response. Keep the following in mind if you use `sendBeacon`:
 
-1. You might end up losing events becase there is no retry, even when 4xx or 5xx responses occur.
+1. There is no retry, even for 4xx or 5xx responses. As a result, you may lose events.
 2. Unlike `fetch`, for which the SDK waits for a response before it sends another request, `sendBeacon` can send events in parallel. This can result in the server receiving events out of order, and lead to some UTM properties not being set for session start events for example.
 {{/partial:admonition}}
 

--- a/content/collections/browser_sdk/en/browser-sdk-2.md
+++ b/content/collections/browser_sdk/en/browser-sdk-2.md
@@ -1127,10 +1127,10 @@ amplitude.track("event")
 Unlike standard network requests, sendBeacon sends events in the background, even if the user closes the browser or leaves the page.
 
 {{partial:admonition type="warning" heading=""}}
-`sendBeacon` sends events in the background. As a result, events `sendBeacon` dispatches don't return a server response. Keep the following in mind if you use `sendBeacon`:
+`sendBeacon` sends events in the background. As a result, events dispatched by `sendBeacon` don't return server responses. Keep the following in mind if you use `sendBeacon`:
 
-1. There is no retry, even for 4xx or 5xx responses. As a result, you may lose events.
-2. Unlike `fetch`, for which the SDK waits for a response before it sends another request, `sendBeacon` can send events in parallel. This can result in the server receiving events out of order, and lead to some UTM properties not being set for session start events for example.
+1. Requests are not retried, including failed requests with 4xx or 5xx responses, so events may be lost.
+2. Event order cannot be guaranteed, as `sendBeacon` may send events in parallel. This can lead to some UTM properties not being set, e.g. for session start events. In contrast, while using `fetch`, the SDK waits for responses before proceeding, guaranteeing event order.
 {{/partial:admonition}}
 
 #### Set the transport to use sendBeacon for all events

--- a/content/collections/browser_sdk/en/browser-sdk-2.md
+++ b/content/collections/browser_sdk/en/browser-sdk-2.md
@@ -1130,7 +1130,7 @@ Unlike standard network requests, sendBeacon sends events in the background, eve
 Because `sendBeacon` sends events in the background, events dispatched from `sendBeacon` don't return a server response. This leads to two important caveats, so be cautious when using `sendBeacon` and keep these in mind:
 
 1. You might end up losing events becase there is no retry, even when 4xx or 5xx responses occur.
-2. Unlike `fetch`, which returns a response that the SDK waits for before sending another request to guarantee event order received by the server, `sendBeacon` may send events in parallel, potentially resulting in the server receiving events out of order. This can lead to some UTM properties not being set for session start events for example.
+2. Unlike `fetch`, for which the SDK waits for a response before it sends another request, `sendBeacon` can send events in parallel. This can result in the server receiving events out of order, and lead to some UTM properties not being set for session start events for example.
 {{/partial:admonition}}
 
 #### Set the transport to use sendBeacon for all events


### PR DESCRIPTION
[AMP-118975]

There is one customer using sendBeacon() (type is ping on the network tab) and gets wrong event orders received by the server which result in some session start events missing UTMs. We should NOT encourage customers to set sendBeacon on initialization to avoid missing UTMs. This PR calls out this caveat. 

[AMP-118975]: https://amplitude.atlassian.net/browse/AMP-118975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ