### PR TITLE
Update receiving-behavioral-cohorts.md

### DIFF
--- a/content/collections/partners/en/receiving-behavioral-cohorts.md
+++ b/content/collections/partners/en/receiving-behavioral-cohorts.md
@@ -116,7 +116,7 @@ POST https://your.domain/lists/$listId/remove
         'traits': {
             '[Amplitude] {$cohort_name}: {$cohort_id}': True / False
         },
-        'userId': ‘$user_id',
+        'userId': ‘$user_id’,
         'context': {
             'integration': {
                 'name': 'Amplitude Cohort Sync',


### PR DESCRIPTION
nit: The syntax highlighting was off because of the difference in ending quote character

in production
<img width="907" alt="Screenshot 2025-01-17 at 1 40 35 PM" src="https://github.com/user-attachments/assets/40090fa5-6e66-4a25-a7ce-a141e7755bae" />

on this branch
<img width="860" alt="Screenshot 2025-01-17 at 1 54 30 PM" src="https://github.com/user-attachments/assets/1bd4da71-9900-46b3-aaf8-258114106651" />
