### PR TITLE
AMP-122299 autocapture suggested event name updates

### DIFF
--- a/content/collections/analytics/en/microscope.md
+++ b/content/collections/analytics/en/microscope.md
@@ -79,7 +79,7 @@ When using Microscope in an [Event Segmentation](/docs/analytics/charts/event-se
 If you have a specific event selected, it's highlighted in the user's stream. You can also choose to show certain event properties as well. Click a user ID or any event in a user's stream to view their profile in the *[User Activity](/docs/analytics/user-data-lookup)* tab.
 
 {{partial:admonition type="note" heading=""}}
-Event names with a *sparkle* icon indicate that we've generated a name to provide more context around the action a user is taking. These are Autocapture events ingested as `Page Viewed`, `Element Clicked`, and `Element Changed`, but we're using property information to make them more valuable in the event stream. You can click on any of them to see their ingested name and properties.
+Event names with a *sparkle* icon indicate that Amplitude has generated a name to provide more context around the action a user is taking. These are Autocapture events ingested as `Page Viewed`, `Element Clicked`, and `Element Changed`, but Amplitude uses property information to make them more valuable in the event stream. Click any of them to see their ingested name and properties.
 {{/partial:admonition}}
 
 ### View Session Replay from a user's event stream

--- a/content/collections/analytics/en/microscope.md
+++ b/content/collections/analytics/en/microscope.md
@@ -78,6 +78,10 @@ When using Microscope in an [Event Segmentation](/docs/analytics/charts/event-se
 
 If you have a specific event selected, it's highlighted in the user's stream. You can also choose to show certain event properties as well. Click a user ID or any event in a user's stream to view their profile in the *[User Activity](/docs/analytics/user-data-lookup)* tab.
 
+{{partial:admonition type="note" heading=""}}
+Event names with a *sparkle* icon indicate that we've generated a name to provide more context around the action a user is taking. These are Autocapture events ingested as `Page Viewed`, `Element Clicked`, and `Element Changed`, but we're using property information to make them more valuable in the event stream. You can click on any of them to see their ingested name and properties.
+{{/partial:admonition}}
+
 ### View Session Replay from a user's event stream
 
 If you are a Growth or an Enterprise customer with the Session Replay add-on, you can launch a session replay from Microscope in the following Amplitude charts: Event Segmentation, Funnel Analysis, Journeys, and User Sessions.

--- a/content/collections/analytics/en/session-replay.md
+++ b/content/collections/analytics/en/session-replay.md
@@ -39,6 +39,10 @@ When viewing a session replay from your [homepage](#h_01HFD88N1M03EH9D8VF32QBBYQ
 
 There is no limit on the length of a session that can be viewed as a replay.
 
+{{partial:admonition type="note" heading=""}}
+Event names with a *sparkle* icon indicate that we've generated a name to provide more context around the action a user is taking. These are Autocapture events ingested as `Page Viewed`, `Element Clicked`, and `Element Changed`, but we're using property information to make them more valuable in the event stream. You can click on any of them to see their ingested name and properties.
+{{/partial:admonition}}
+
 **NOTE:** By default, Amplitude will store your replays for 90 days. Upon request, this can be changed to 30 days to comply with stricter privacy requirements. If you change your retention period, the changes will apply only to new sessions, and not those that pre-date the change.
 
 To access Session Replay from a user’s event stream, use the [User Lookup](/docs/analytics/user-data-lookup) feature.

--- a/content/collections/analytics/en/session-replay.md
+++ b/content/collections/analytics/en/session-replay.md
@@ -40,7 +40,7 @@ When viewing a session replay from your [homepage](#h_01HFD88N1M03EH9D8VF32QBBYQ
 There is no limit on the length of a session that can be viewed as a replay.
 
 {{partial:admonition type="note" heading=""}}
-Event names with a *sparkle* icon indicate that we've generated a name to provide more context around the action a user is taking. These are Autocapture events ingested as `Page Viewed`, `Element Clicked`, and `Element Changed`, but we're using property information to make them more valuable in the event stream. You can click on any of them to see their ingested name and properties.
+Event names with a *sparkle* icon indicate that Amplitude has generated a name to provide more context around the action a user is taking. These are Autocapture events ingested as `Page Viewed`, `Element Clicked`, and `Element Changed`, but Amplitude uses property information to make them more valuable in the event stream. Click any of them to see their ingested name and properties.
 {{/partial:admonition}}
 
 **NOTE:** By default, Amplitude will store your replays for 90 days. Upon request, this can be changed to 30 days to comply with stricter privacy requirements. If you change your retention period, the changes will apply only to new sessions, and not those that pre-date the change.

--- a/content/collections/analytics/en/user-data-lookup.md
+++ b/content/collections/analytics/en/user-data-lookup.md
@@ -21,7 +21,7 @@ To search for a specific user:
 
 1. In Amplitude, navigate to *Users > User Profiles*.
 2. In the search box above the active user list, enter the user ID or device ID, or click *Advanced Search* to search by user property values.
-  
+
 Searching by user property values displays a list of users who match the criteria you specified, **and** who triggered at least one active event in the last six months.
 
 When you find the user you're looking for, click their ID to view their user profile. The profile has two sections: the **user details** section—where the user's most-recent properties are visible—and the **user history** section, which contains the user's entire event history and displays all events received from them for a given day, which you can specify using the date picker.
@@ -32,7 +32,7 @@ User details displays properties that describe the user, and allows you to custo
 
 ## User history
 
-The user history panel has 6 tabs, Activity, Insights, Session Replays, Cohorts, Experiments, and Flags. 
+The user history panel has 6 tabs, Activity, Insights, Session Replays, Cohorts, Experiments, and Flags.
 
 ### Activity
 
@@ -56,6 +56,10 @@ You can choose up to ten events from a user's event stream to view in a funnel o
 2. Click *Create Chart* and choose *Segmentation* or *Funnel* to visualize the user's event stream data.
 
 ![event_stream_to_chart.png](/docs/output/img/analytics/event_stream_to_chart.png)
+
+{{partial:admonition type="note" heading=""}}
+Event names with a *sparkle* icon indicate that we've generated a name to provide more context around the action a user is taking. These are Autocapture events ingested as `Page Viewed`, `Element Clicked`, and `Element Changed`, but we're using property information to make them more valuable in the event stream. You can click on any of them to see their ingested name and properties.
+{{/partial:admonition}}
 
 #### Raw data fields
 

--- a/content/collections/analytics/en/user-data-lookup.md
+++ b/content/collections/analytics/en/user-data-lookup.md
@@ -58,7 +58,7 @@ You can choose up to ten events from a user's event stream to view in a funnel o
 ![event_stream_to_chart.png](/docs/output/img/analytics/event_stream_to_chart.png)
 
 {{partial:admonition type="note" heading=""}}
-Event names with a *sparkle* icon indicate that we've generated a name to provide more context around the action a user is taking. These are Autocapture events ingested as `Page Viewed`, `Element Clicked`, and `Element Changed`, but we're using property information to make them more valuable in the event stream. You can click on any of them to see their ingested name and properties.
+Event names with a *sparkle* icon indicate that Amplitude has generated a name to provide more context around the action a user is taking. These are Autocapture events ingested as `Page Viewed`, `Element Clicked`, and `Element Changed`, but Amplitude uses property information to make them more valuable in the event stream. Click any of them to see their ingested name and properties.
 {{/partial:admonition}}
 
 #### Raw data fields

--- a/content/collections/sections/en/session-replay.md
+++ b/content/collections/sections/en/session-replay.md
@@ -35,9 +35,13 @@ When viewing a session replay from your homepage or from a search, the user's ev
 
 Session Replay supports user sessions of any length.
 
+{{partial:admonition type="note" heading=""}}
+Event names with a *sparkle* icon indicate that we've generated a name to provide more context around the action a user is taking. These are Autocapture events ingested as `Page Viewed`, `Element Clicked`, and `Element Changed`, but we're using property information to make them more valuable in the event stream. You can click on any of them to see their ingested name and properties.
+{{/partial:admonition}}
+
 ### View Session Replay from User Look-Up
 
-To access Session Replay from a user’s event stream, use the [User Look-Up](/docs/analytics/user-data-lookup) feature. This can be helpful if a user has reported a potential bug during their session, or if you want to understand whether a user's experience is representative of a bigger trend. 
+To access Session Replay from a user’s event stream, use the [User Look-Up](/docs/analytics/user-data-lookup) feature. This can be helpful if a user has reported a potential bug during their session, or if you want to understand whether a user's experience is representative of a bigger trend.
 
 Find the user with User Look-Up (you’ll need their user ID to do this), then click *Play Session* next to the session you're looking for in the event stream. The replay appears to the right, where you can review session activity. You can generate a link to share the replay with your team from the view in a User Look-Up event stream. Click *Copy URL* from the view to copy the link. 
 

--- a/content/collections/sections/en/session-replay.md
+++ b/content/collections/sections/en/session-replay.md
@@ -36,7 +36,7 @@ When viewing a session replay from your homepage or from a search, the user's ev
 Session Replay supports user sessions of any length.
 
 {{partial:admonition type="note" heading=""}}
-Event names with a *sparkle* icon indicate that we've generated a name to provide more context around the action a user is taking. These are Autocapture events ingested as `Page Viewed`, `Element Clicked`, and `Element Changed`, but we're using property information to make them more valuable in the event stream. You can click on any of them to see their ingested name and properties.
+Event names with a *sparkle* icon indicate that Amplitude has generated a name to provide more context around the action a user is taking. These are Autocapture events ingested as `Page Viewed`, `Element Clicked`, and `Element Changed`, but Amplitude uses property information to make them more valuable in the event stream. Click any of them to see their ingested name and properties.
 {{/partial:admonition}}
 
 ### View Session Replay from User Look-Up


### PR DESCRIPTION
This PR updates 3 places in our public docs (microscope, user-data-lookup and session-replay) adding a note mentioning that they might see Autocapture Suggested Event Names in these event streams.

Note being added

> Event names with a *sparkle* icon indicate that we've generated a name to provide more context around the action a user is taking. These are Autocapture events ingested as `Page Viewed`, `Element Clicked`, and `Element Changed`, but we're using property information to make them more valuable in the event stream. You can click on any of them to see their ingested name and properties.
