### PR TITLE
Rename web experiment properties

### DIFF
--- a/content/collections/web_experiment/en/targeting.md
+++ b/content/collections/web_experiment/en/targeting.md
@@ -39,9 +39,9 @@ By default, a new Web Experiment targets all users. Audience targeting enables y
 
 If any segments match, Amplitude buckets that user into a variant based on the configured rollout and variant distribution. For a segment to match, it must meet all conditions you set.
 
-### Local properties
+### Browser properties (local)
 
-Local properties are available client-side and don't require network requests. This enables Amplitude to evaluate them with low latency.
+Browser properties are available client-side and don't require network requests. This enables Amplitude to evaluate them with low latency.
 
 | Parameter            | Description                                                                                                                                                                                                                                                                                                                          |
 |----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -57,9 +57,13 @@ Local properties are available client-side and don't require network requests. T
 | Browser              | The user's browser: `Safari`, `Chrome`, `Firefox`, `Edge`, `Opera`.                                                                                                                                                                                                                                                                  |
 | Freeform properties  | Custom properties for the user set using the [`IntegrationPlugin`](/docs/web-experiment/implementation#integrate-with-a-third-party-cdp).                                                                                                                                                                                    |
 
-### Remote properties
+### User properties (remote)
 
-Remote properties enable advanced targeting based on [Amplitude ID resolution](/docs/feature-experiment/remote-evaluation#amplitude-id-resolution), [IP geolocation](/docs/feature-experiment/remote-evaluation#geolocation), [property canonicalization](/docs/feature-experiment/remote-evaluation#canonicalization), [behavioral cohorts](/docs/feature-experiment/remote-evaluation#cohort-membership), and historical [user properties](/docs/feature-experiment/remote-evaluation#user-properties). Targeting remote properties may increase page display latency since network requests are required.
+{{partial:admonition type='note'}}
+Web experiment user property targeting is not available on Starter or Plus plans.
+{{/partial:admonition}}
+
+You can perform advanced targeting based on [Amplitude ID resolution](/docs/feature-experiment/remote-evaluation#amplitude-id-resolution), [IP geolocation](/docs/feature-experiment/remote-evaluation#geolocation), [property canonicalization](/docs/feature-experiment/remote-evaluation#canonicalization), [behavioral cohorts](/docs/feature-experiment/remote-evaluation#cohort-membership), and historical [user properties](/docs/feature-experiment/remote-evaluation#user-properties). Targeting user properties may increase page display latency since network requests are required.
 
 | Parameter                  | Description                                                                                            |
 |----------------------------|--------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
We made a decision to update some naming in-product for web experiment targeting to remove language around local/remote evaluation for the web exp persona so only the docs will contain the details around evaluation.

Local property targeting -> Browser property targeting
Remote property targeting -> User property targeting

There are no changes for feature experiment.

This is the update to the in-product segment control:
![Screenshot 2025-01-27 at 9 31 39 AM](https://github.com/user-attachments/assets/162d3f14-7dc0-456d-9a47-85b237eca389)

docs update:
![Screenshot 2025-01-27 at 9 29 37 AM](https://github.com/user-attachments/assets/4e72b705-0464-45e3-89fc-ef15dbc68d8a)
