### PR TITLE
Add compatibility matrix for flutter docs for 3.x and 4.x

### DIFF
--- a/content/collections/flutter_sdk/en/flutter-sdk-4-0.md
+++ b/content/collections/flutter_sdk/en/flutter-sdk-4-0.md
@@ -18,6 +18,16 @@ package_name: amplitude_flutter
 ---
 This is the official documentation for the Amplitude Analytics Flutter SDK. The Flutter SDK lets you send events from your Flutter application to Amplitude.
 
+## Compatibility
+
+From Amplitude Flutter v4, we bump up the kotlin version to v1.9.22 to support latest Gradle.
+
+The following matrix lists the minimum support for Amplitude Flutter SDK version.
+
+| Amplitude Flutter |  Dart   | Flutter | Gradle | Android Gradle Plugin | Kotlin Gradle Plugin |
+|-------------------|---------|---------|--------|-----------------------|-----------------------|
+| >= 4.0.0          | >=3.3   | >=3.7   | 8.2    | 8.2.2                 | 1.9.22                |
+
 ## Install the SDK
 
 1. Go to the `pubspec.yaml` file and add Amplitude SDK as a dependency.

--- a/content/collections/flutter_sdk/en/flutter-sdk.md
+++ b/content/collections/flutter_sdk/en/flutter-sdk.md
@@ -22,6 +22,17 @@ platform: Flutter
 ---
 This is the official documentation for the Amplitude Analytics Flutter SDK.
 
+## Compatibility
+
+From Amplitude Flutter v3.11.0, we bump up the kotlin version to v1.7.10 to support latest Gradle. For Gradle Version lower than v6.7.1, we recommend to use the Amplitude Flutter v3.10.0. The following matrix lists the minimum support for Amplitude Flutter SDK version.
+
+From Amplitude Flutter 3.16.5, we switched from `package:js ^v0.6.3` to using `dart:js_interop` for Flutter web, which requires dart 3.1+.
+
+|Amplitude Flutter  |Dart    |Gradle   |Android Gradle Plugin|Kotlin Gradle Plugin|
+|-------------------|--------|---------|---------------------|--------------------|
+| >= 3.16.5         | >= 3.1 |   6.7.1 | 3.6.4               | 1.7.10             |
+| >= 3.11 <= 3.16.4 | >=2.12 |   6.7.1 | 3.6.4               | 1.7.10             |
+
 ## Install the SDK
 
 1. Go to the `pubspec.yaml` file and add Amplitude SDK as a dependency.
@@ -86,7 +97,7 @@ For other default configurations:
 | `setOptOut()` | `bool`. Opt the user out of tracking. For example, `Amplitude.getInstance().setOptOut(true)`.| `false` |
 | `trackingSessionEvents()` | `bool`. Whether to automatically log "[Amplitude] Session Start" and "[Amplitude] Session End" session events corresponding to the start and end of a user's session. Not supported on Flutter Web. [Learn more](/docs/#flutter-web-support). | `false` |
 | `useAppSetIdForDeviceId()` | Only for Android. Whether to use app ser id as device id on Android side.  Check [here](../android/#app-set-id) for the required module and permission. For example, `Amplitude.getInstance().useAppSetIdForDeviceId(true)` | By default, the deviceId will be UUID+"R" |
-    
+
 ### Configure batching behavior
 
 To support high-performance environments, the SDK sends events in batches. Every event logged by the `logEvent` method is queued in memory. Events are flushed in batches in background. You can customize batch behavior with `setEventUploadThreshold`. By default, the serverUrl will be `https://api2.amplitude.com/`. This SDK doesn't support batch mode, the [batch API](/docs/apis/analytics/batch-event-upload) endpoint.
@@ -316,7 +327,7 @@ If Joe is in 'sport' 'tennis' and 'soccer', then the `groupName` would be '["ten
 Amplitude.getInstance().setGroup("sport", ["tennis", "soccer"]);
 ```
 {{/partial:admonition}}
-    
+
 
 {{partial:admonition type="note" heading=""}}
 Event-level groups is unavailable and its availability is yet to be determined.


### PR DESCRIPTION
Our docs do not include a compatibility for Flutter, though our Github repo READMEs do. Our React Native docs have the compatibility matrix, so adding here for consistency and convenience for users.