### PR TITLE
Update S3 Cohort doc to note about the change to IAM role-based access

### DIFF
--- a/content/collections/destination-catalog/en/amazon-s3-cohort.md
+++ b/content/collections/destination-catalog/en/amazon-s3-cohort.md
@@ -16,6 +16,10 @@ updated_at: 1720113620
 
 Set up this integration to send cohorts to an Amazon S3 bucket. This enables you to export groups of users out of Amplitude and synchronize them with other databases or stored procedures you've built off your Amazon S3 bucket. From there, you can use Amplitude cohorts in internal analytics dashboards and internal personalization engines.
 
+{{partial:admonition type="note" title=""}}
+We recently updated our security model to align with AWS best practices. New setups now default to IAM role-based access to improve security and prevent over-permissioning. Existing S3 destinations remain unchanged to avoid disruption. If you would like to update your old destinations to IAM roles, you will need to delete your existing connection and reconfigure the cohort sync destination, as it will be set up with the new access model.
+{{/partial:admonition}}
+
 ## Setup
 
 ### Prerequisites

--- a/content/collections/destination-catalog/en/amazon-s3-cohort.md
+++ b/content/collections/destination-catalog/en/amazon-s3-cohort.md
@@ -17,7 +17,9 @@ updated_at: 1720113620
 Set up this integration to send cohorts to an Amazon S3 bucket. This enables you to export groups of users out of Amplitude and synchronize them with other databases or stored procedures you've built off your Amazon S3 bucket. From there, you can use Amplitude cohorts in internal analytics dashboards and internal personalization engines.
 
 {{partial:admonition type="note" title=""}}
-We recently updated our security model to align with AWS best practices. New setups now default to IAM role-based access to improve security and prevent over-permissioning. Existing S3 destinations remain unchanged to avoid disruption. If you would like to update your old destinations to IAM roles, you will need to delete your existing connection and reconfigure the cohort sync destination, as it will be set up with the new access model.
+Amplitude updated its security model to better align with AWS best practices. New instances of this destination default to IAM role-based access to improve security and prevent over-permissioning. Existing S3 destinations remain unchanged to avoid disruption. 
+
+To update your existing destinations to IAM roles, delete the existing connection and reconfigure the cohort sync destination to use the updated security model.
 {{/partial:admonition}}
 
 ## Setup


### PR DESCRIPTION
- We want to add a “Note” under the Setup section for S3 Cohort, similar to Marketo. [Marketo Static List](https://amplitude.com/docs/data/destination-catalog/marketo-static-list)