### PR TITLE
Flutter SDK docs update install instructions

### DIFF
--- a/content/collections/flutter_sdk/en/flutter-sdk-4.md
+++ b/content/collections/flutter_sdk/en/flutter-sdk-4.md
@@ -30,14 +30,11 @@ The following matrix lists the minimum support for Amplitude Flutter SDK version
 
 ## Install the SDK
 
-1. Go to the `pubspec.yaml` file and add Amplitude SDK as a dependency.
+Run the following to grab the latest version of `amplitude_flutter`, which will add it to your `pubspec.yaml` then retrieve dependencies:
 
-    ```yml
-    dependencies:
-        amplitude_flutter: ^4.1.0
+    ```bash
+    flutter pub add amplitude_flutter
     ```
-
-2. Run `flutter pub get` in the terminal to install the SDK.
 
 ### iOS installation
 

--- a/content/collections/flutter_sdk/en/flutter-sdk-4.md
+++ b/content/collections/flutter_sdk/en/flutter-sdk-4.md
@@ -30,7 +30,7 @@ The following matrix lists the minimum support for Amplitude Flutter SDK version
 
 ## Install the SDK
 
-Run the following to grab the latest version of `amplitude_flutter`, which will add it to your `pubspec.yaml` then retrieve dependencies:
+Run the following command to get the latest version of `amplitude_flutter`, add it to your `pubspec.yaml`, then retrieve dependencies:
 
     ```bash
     flutter pub add amplitude_flutter

--- a/content/collections/flutter_sdk/en/flutter-sdk-4.md
+++ b/content/collections/flutter_sdk/en/flutter-sdk-4.md
@@ -34,7 +34,7 @@ The following matrix lists the minimum support for Amplitude Flutter SDK version
 
     ```yml
     dependencies:
-        amplitude_flutter: ^4.0.0-beta.7
+        amplitude_flutter: ^4.1.0
     ```
 
 2. Run `flutter pub get` in the terminal to install the SDK.


### PR DESCRIPTION
Previously instructions directed users to install a minimum version that was a beta (`^4.0.0-beta.7`). Rather than specifying a specific version, direct users to use the method that `pub.dev` recommends (`flutter pub add amplitude_flutter`) which will never be out of date.