### PR TITLE
Using the G&S NPM package with 3rd party analytics

### DIFF
--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -86,11 +86,8 @@ First, the initialization code requires you to map the `user_id` and `device_id`
 
 {{partial:tabs tabs="script, npm"}}
 {{partial:tab name="script"}}
-Place the script tag below your Amplitude script tag.
-```html
-<script src="https://cdn.amplitude.com/script/API_KEY.engagement.js"></script>
-<script>amplitude.add(window.engagement.plugin())</script>
-
+Make sure you've added the Engagement script tag to your site before continuing.
+```js
 analytics.ready(() => {
   await window.engagement.boot({
     user: {
@@ -129,7 +126,8 @@ npm install @amplitude/engagement-browser
 Connect Guides and Surveys with Segment:
 ```ts
 import { init as engagementInit } from '@amplitude/engagement-browser';
-engagementInit(engagementPlugin());
+
+engagementInit("API_KEY");
 
 analytics.ready(() => {
   await window.engagement.boot({

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -63,6 +63,7 @@ engagement.init(apiKey: string, options: { serverZone: "US" | "EU" }): void
 | ---------------------- | ------------------------------ | ----------------------------------------------------------------------- |
 | `apiKey`               | `string`                       | Required. The API key of the Amplitude project to load.                 |
 | `options.serverZone`   | `"US"` or `"EU"`               | Required. What server zone to send requests to.                         |
+
 {{/partial:collapse}}
 
 This initialization code accepts parameters that define the user and any integrations.
@@ -93,6 +94,7 @@ await window.engagement.boot({
   ],
 });
 ```
+
 
 {{partial:collapse name="Initialize with Segment analytics"}}
 Initializing the SDK and launching a guide or survey with third-party analytics requires a few more steps.

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -82,35 +82,85 @@ await window.engagement.boot({
 Initializing the SDK and launching a guide or survey with third-party analytics requires a few more steps.
 
 First, the initialization code requires you to map the `user_id` and `device_id` fields, and optionally configure event forwarding to enable event-based triggers.
-```js
+
+
+{{partial:tabs tabs="script, npm"}}
+{{partial:tab name="script"}}
+Place the script tag below your Amplitude script tag.
+```html
+<script src="https://cdn.amplitude.com/script/API_KEY.engagement.js"></script>
+<script>amplitude.add(window.engagement.plugin())</script>
+
 analytics.ready(() => {
-   await window.engagement.boot({
-  user: {
-    // User Provider: Guides and Surveys requires either user_id or device_id for user identification
-    user_id: analytics.user().id(),
-    device_id: analytics.user().anonymousId(),
-    user_properties: {},
-  },
-  integrations: [
-    {
-     // Tracking Provider: Pass Guides and Surveys events to the 3rd party analytics provier
-      track: (event) => {
-        analytics.track(event.event_type, event.event_properties)
-      }
+  await window.engagement.boot({
+    user: {
+      // User Provider: Guides and Surveys requires either user_id or device_id for user identification
+      user_id: analytics.user().id(),
+      device_id: analytics.user().anonymousId(),
+      user_properties: {},
     },
-  ],
-});
+    integrations: [
+      {
+        // Tracking Provider: Pass Guides and Surveys events to the 3rd party analytics provier
+        track: (event) => {
+          analytics.track(event.event_type, event.event_properties)
+        }
+      },
+    ],
+  });
 
-// (Optional) Forward events from segment to do event-based triggers for Guides and Surveys. These events aren't sent to the server
-analytics.on('track', (event, properties, options) => {
-  window.engagement.forwardEvent({ event_type: event, event_properties: properties});
-});
+  // (Optional) Forward events from segment to do event-based triggers for Guides and Surveys. These events aren't sent to the server
+  analytics.on('track', (event, properties, options) => {
+    window.engagement.forwardEvent({ event_type: event, event_properties: properties});
+  });
 
-analytics.on('page', (event, properties, options) => {
-  window.engagement.forwardEvent({ event_type: event, event_properties: properties});
+  analytics.on('page', (event, properties, options) => {
+    window.engagement.forwardEvent({ event_type: event, event_properties: properties});
+  });
 });
 ```
+{{/partial:tab}}
+{{partial:tab name="npm"}}
+Import the Guides and Surveys package
+```bash
+npm install @amplitude/engagement-browser
+```
 
+Connect Guides and Surveys with Segment:
+```ts
+import { init as engagementInit } from '@amplitude/engagement-browser';
+engagementInit(engagementPlugin());
+
+analytics.ready(() => {
+  await window.engagement.boot({
+    user: {
+      // User Provider: Guides and Surveys requires either user_id or device_id for user identification
+      user_id: analytics.user().id(),
+      device_id: analytics.user().anonymousId(),
+      user_properties: {},
+    },
+    integrations: [
+      {
+        // Tracking Provider: Pass Guides and Surveys events to the 3rd party analytics provier
+        track: (event) => {
+          analytics.track(event.event_type, event.event_properties)
+        }
+      },
+    ],
+  });
+
+  // (Optional) Forward events from segment to do event-based triggers for Guides and Surveys. These events aren't sent to the server
+  analytics.on('track', (event, properties, options) => {
+    window.engagement.forwardEvent({ event_type: event, event_properties: properties});
+  });
+
+  analytics.on('page', (event, properties, options) => {
+    window.engagement.forwardEvent({ event_type: event, event_properties: properties});
+  });
+});
+```
+{{/partial:tab}}
+{{/partial:tabs}}
 {{/partial:collapse}}
 
 ### Verify installation and initialization

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -101,14 +101,13 @@ analytics.ready(() => {
   ],
 });
 
-    // (Optional) Forward events from segment to do event-based triggers for Guides and Surveys. These events aren't sent to the server
-    analytics.on('track', (event, properties, options) => {
-  	  window.engagement.forwardEvent({ event_type: event, event_properties: properties});
-    });
+// (Optional) Forward events from segment to do event-based triggers for Guides and Surveys. These events aren't sent to the server
+analytics.on('track', (event, properties, options) => {
+  window.engagement.forwardEvent({ event_type: event, event_properties: properties});
+});
 
-    analytics.on('page', (event, properties, options) => {
-  	  window.engagement.forwardEvent({ event_type: event, event_properties: properties});
-    });
+analytics.on('page', (event, properties, options) => {
+  window.engagement.forwardEvent({ event_type: event, event_properties: properties});
 });
 ```
 

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -84,7 +84,7 @@ Initializing the SDK and launching a guide or survey with third-party analytics 
 First, the initialization code requires you to map the `user_id` and `device_id` fields, and optionally configure event forwarding to enable event-based triggers.
 
 
-{{partial:tabs tabs="script, npm"}}
+{{partial:tabs tabs="script, npm, yarn"}}
 {{partial:tab name="script"}}
 Make sure you've added the Engagement script tag to your site before continuing.
 ```js
@@ -121,6 +121,47 @@ analytics.ready(() => {
 Import the Guides and Surveys package
 ```bash
 npm install @amplitude/engagement-browser
+```
+
+Connect Guides and Surveys with Segment:
+```ts
+import { init as engagementInit } from '@amplitude/engagement-browser';
+
+engagementInit("API_KEY");
+
+analytics.ready(() => {
+  await window.engagement.boot({
+    user: {
+      // User Provider: Guides and Surveys requires either user_id or device_id for user identification
+      user_id: analytics.user().id(),
+      device_id: analytics.user().anonymousId(),
+      user_properties: {},
+    },
+    integrations: [
+      {
+        // Tracking Provider: Pass Guides and Surveys events to the 3rd party analytics provier
+        track: (event) => {
+          analytics.track(event.event_type, event.event_properties)
+        }
+      },
+    ],
+  });
+
+  // (Optional) Forward events from segment to do event-based triggers for Guides and Surveys. These events aren't sent to the server
+  analytics.on('track', (event, properties, options) => {
+    window.engagement.forwardEvent({ event_type: event, event_properties: properties});
+  });
+
+  analytics.on('page', (event, properties, options) => {
+    window.engagement.forwardEvent({ event_type: event, event_properties: properties});
+  });
+});
+```
+{{/partial:tab}}
+{{partial:tab name="yarn"}}
+Import the Guides and Surveys package
+```bash
+yarn add @amplitude/engagement-browser
 ```
 
 Connect Guides and Surveys with Segment:

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -49,7 +49,23 @@ amplitude.add(engagementPlugin());
 
 ### Third-party analytics provider
 
-Using the Guides and Surveys standalone SDK with another analytics provider requires extra configuration to help map properties to Amplitude. This initialization code accepts parameters that define the user and any integrations.
+Using the Guides and Surveys standalone SDK with another analytics provider requires extra configuration to help map properties to Amplitude.
+
+Calling `init` is only required when loading Guides and Surveys via NPM. If you're using the script installation, skip straight to calling `boot`.
+
+```js
+engagement.init(apiKey: string): void
+```
+
+| Parameter              | Type                           | Description                                                             |
+| ---------------------- | ------------------------------ | ----------------------------------------------------------------------- |
+| `apiKey`               | `string`                       | Required. The API key of the Amplitude project to load.                 |
+
+```js
+await window.engagement.init("API_KEY");
+```
+
+This initialization code accepts parameters that define the user and any integrations.
 
 ```js
 engagement.boot(options: BootOptions): Promise<void>

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -184,7 +184,7 @@ Connect Guides and Surveys with Segment:
 ```ts
 import { init as engagementInit } from '@amplitude/engagement-browser';
 
-engagementInit("API_KEY");
+engagementInit("API_KEY", { serverZone: "US" });
 
 analytics.ready(() => {
   await window.engagement.boot({

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -56,12 +56,13 @@ Using the Guides and Surveys standalone SDK with another analytics provider requ
 Calling `init` is only required when loading Guides and Surveys via NPM or Yarn. If you're using the script installation, skip straight to calling `boot`.
 
 ```js
-engagement.init(apiKey: string): void
+engagement.init(apiKey: string, options: { serverZone: "US" | "EU" }): void
 ```
 
 | Parameter              | Type                           | Description                                                             |
 | ---------------------- | ------------------------------ | ----------------------------------------------------------------------- |
 | `apiKey`               | `string`                       | Required. The API key of the Amplitude project to load.                 |
+| `options.serverZone`   | `"US"` or `"EU"`               | Required. What server zone to send requests to.                         |
 {{/partial:collapse}}
 
 This initialization code accepts parameters that define the user and any integrations.
@@ -142,7 +143,7 @@ Connect Guides and Surveys with Segment:
 ```ts
 import { init as engagementInit } from '@amplitude/engagement-browser';
 
-engagementInit("API_KEY");
+engagementInit("API_KEY", { serverZone: "US" });
 
 analytics.ready(() => {
   await window.engagement.boot({

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -53,7 +53,7 @@ Using the Guides and Surveys standalone SDK with another analytics provider requ
 
 {{partial:collapse name="Usign NPM or Yarn"}}
 
-Calling `init` is only required when loading Guides and Surveys via NPM or Yarn. If you're using the script installation, skip straight to calling `boot`.
+Calling `init` is only required when loading Guides and Surveys using NPM or Yarn. If you're using the script installation, skip straight to calling `boot`.
 
 ```js
 engagement.init(apiKey: string, options: { serverZone: "US" | "EU" }): void

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -51,7 +51,9 @@ amplitude.add(engagementPlugin());
 
 Using the Guides and Surveys standalone SDK with another analytics provider requires extra configuration to help map properties to Amplitude.
 
-Calling `init` is only required when loading Guides and Surveys via NPM. If you're using the script installation, skip straight to calling `boot`.
+{{partial:collapse name="Usign NPM or Yarn"}}
+
+Calling `init` is only required when loading Guides and Surveys via NPM or Yarn. If you're using the script installation, skip straight to calling `boot`.
 
 ```js
 engagement.init(apiKey: string): void
@@ -60,10 +62,7 @@ engagement.init(apiKey: string): void
 | Parameter              | Type                           | Description                                                             |
 | ---------------------- | ------------------------------ | ----------------------------------------------------------------------- |
 | `apiKey`               | `string`                       | Required. The API key of the Amplitude project to load.                 |
-
-```js
-await window.engagement.init("API_KEY");
-```
+{{/partial:collapse}}
 
 This initialization code accepts parameters that define the user and any integrations.
 


### PR DESCRIPTION
Add instructions for using Segment with the NPM package. This was an edge case we hadn't covered in the original docs, and is tricky because it requires calling `init`. Normally the `init` call isn't needed, because it's done via the dynamic script, but when installing via NPM it's required.

I tested these instructions locally and they worked well for me. Instructions are a bit rough around the edges, but there's a customer who's actively planning on using this setup, so I'd like to get these out sooner rather than later.

### Full instructions for using Segment with NPM


Import the Guides and Surveys package
```bash
yarn add @amplitude/engagement-browser
```

Connect Guides and Surveys with Segment:
```ts
import { init as engagementInit } from '@amplitude/engagement-browser';

// This was the piece that was missing before
engagementInit("API_KEY");

analytics.ready(() => {
  await window.engagement.boot({
    user: {
      // User Provider: Guides and Surveys requires either user_id or device_id for user identification
      user_id: analytics.user().id(),
      device_id: analytics.user().anonymousId(),
      user_properties: {},
    },
    integrations: [
      {
        // Tracking Provider: Pass Guides and Surveys events to the 3rd party analytics provier
        track: (event) => {
          analytics.track(event.event_type, event.event_properties)
        }
      },
    ],
  });

  // (Optional) Forward events from segment to do event-based triggers for Guides and Surveys. These events aren't sent to the server
  analytics.on('track', (event, properties, options) => {
    window.engagement.forwardEvent({ event_type: event, event_properties: properties});
  });

  analytics.on('page', (event, properties, options) => {
    window.engagement.forwardEvent({ event_type: event, event_properties: properties});
  });
});
```