### PR TITLE
[Guides and Surveys] Update incorrect docs links

### DIFF
--- a/content/collections/guides_and_surveys/en/build-a-survey.md
+++ b/content/collections/guides_and_surveys/en/build-a-survey.md
@@ -54,4 +54,4 @@ This logic asks a followup question to users who gave a 1-3, and shows a thank y
 
 ## Setup and target your survey
 
-Setup and targeting of surveys works the same as for [guides](docs/guides-and-surveys/guides/setup-and-target). Follow those instructions for your survey.
+Setup and targeting of surveys works the same as for [guides](/docs/guides-and-surveys/guides/setup-and-target). Follow those instructions for your survey.

--- a/content/collections/guides_and_surveys/en/survey-overview.md
+++ b/content/collections/guides_and_surveys/en/survey-overview.md
@@ -13,7 +13,7 @@ Surveys are a source of user feedback. Like [guides](/docs/guides-and-surveys/gu
 
 ## Survey templates
 
-Surveys offer different templates than [guides](/docs/guides-and-surveys/guides/guide-templates). When you create a new survey, you can start with a blank guide, or use a template. Guides includes the following templates:
+Surveys offer different templates than [guides](/docs/guides-and-surveys/guides/guide-overview#guide-templates). When you create a new survey, you can start with a blank guide, or use a template. Guides includes the following templates:
 
 | Template      | Use case                                                                                                                 |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
JIRA Task: https://amplitude.atlassian.net/browse/FOO-1355

Changes: 
- Update Survey → Overview → Survey templates -> `guide` link
Preview link: https://amplitude-docs-git-ninooooonin-foo-1355-fi-c652c0-amplitude-inc.vercel.app/docs/guides-and-surveys/surveys/survey-overview#survey-templates

- Update Surveys → Build a survey → Setup and target your survey -> `guides` link
Preview link:
https://amplitude-docs-git-ninooooonin-foo-1355-fi-c652c0-amplitude-inc.vercel.app/docs/guides-and-surveys/surveys/build-a-survey#setup-and-target-your-survey