### PR TITLE
AMP-126286 Update docs to /csv instead of /query

### DIFF
--- a/content/collections/api/en/dashboard-rest.md
+++ b/content/collections/api/en/dashboard-rest.md
@@ -144,18 +144,18 @@ You can use the Dashboard REST API to export data from data tables. Just query a
 ## Get results from an existing chart
 
 Get JSON results from any saved chart via chart ID.
-`GET https://amplitude.com/api/3/chart/chart_id/query`
+`GET https://amplitude.com/api/3/chart/chart_id/csv`
 
 {{partial:tabs tabs="cURL, HTTP"}}
 {{partial:tab name="cURL"}}
 ```bash
-curl --location --request GET 'https://amplitude.com/api/3/chart/:chart_id/query' \
+curl --location --request GET 'https://amplitude.com/api/3/chart/:chart_id/csv' \
 -u '{api_key}:{secret_key}'
 ```
 {{/partial:tab}}
 {{partial:tab name="HTTP"}}
 ```bash
-GET /api/3/chart/:chart_id/query HTTP/1.1
+GET /api/3/chart/:chart_id/csv HTTP/1.1
 Host: amplitude.com
 Authorization: Basic {api-key}:{secret-key} #credentials must be base64 encoded
 ```


### PR DESCRIPTION
It doesn't make sense that we ask people to use /query as the response format makes more sense for our charts better for them to just call /csv instead. It is confusing to end customers https://amplitude.slack.com/archives/C02RN1UPBNY/p1741704106052699 and https://community.amplitude.com/building-and-sharing-your-analysis-58/chart-api-does-not-return-series-labels-1272 and https://community.amplitude.com/ideas/add-column-headers-to-chart-api-response-4317