### PR TITLE
Clarify install instructions

### DIFF
--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -341,7 +341,7 @@ interface GuideOrSuvey {
 
 ## Show
 
-Display a specific guide or survey. This will ignore any targeting rules and limits except for page targeting.
+Display a specific guide or survey. This ignores any targeting rules and limits except for page targeting.
 
 ```js
 engagement.gs.show(key: string, stepIndex?: number): void

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -354,7 +354,7 @@ engagement.gs.show(key: string, stepIndex?: number): void
 
 ## Forward event
 
-Forwared third-party Analytics events to the Guides and Surveys SDK to trigger guides and surveys that use the `*On event tracked*` [trigger](/docs/guides-and-surveys/guides/guides/setup-and-target#triggers).
+Forward third-party Analytics events to the Guides and Surveys SDK to trigger guides and surveys that use the `*On event tracked*` [trigger](/docs/guides-and-surveys/guides/setup-and-target#triggers).
 
 ```js
 engagement.forwardEvent(event: Event): void

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -55,7 +55,7 @@ But, instead of calling `amplitude.add(window.engagement.plugin())`, you need to
 
 #### Initialize SDK
 
-Calling `init` fully initializes the bundle and registers `engagement` on the global window object.
+Call `init` to  fully initialize the bundle and register `engagement` on the global window object.
 
 ```js
 engagement.init(apiKey: string, options: { serverZone: "US" | "EU", logger: Logger, logLevel: LogLevel }): void

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -103,7 +103,7 @@ await window.engagement.boot({
 });
 ```
 
-Finally, if you want to use *On event tracked* [triggers](/docs/guides-and-surveys/guides/guides/setup-and-target#triggers), you need to forward events from your third-party analytics provider to Guides and Surveys. These events are not sent to the server.
+To use *On event tracked* [triggers](/docs/guides-and-surveys/guides/guides/setup-and-target#triggers),  forward events from your third-party analytics provider to Guides and Surveys. The Guides and Surveys SDK doesn't send these events to the server.
 
 ```js
 analytics.on('track', (event, properties, options) => { // Example for Segment Analytics

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -49,14 +49,15 @@ amplitude.add(engagementPlugin());
 
 ### Third-party analytics provider
 
-Using the Guides and Surveys standalone SDK with another analytics provider requires extra configuration to help map properties to Amplitude.
+If you don't use the Amplitude Analytics [Browser SDK 2](https://amplitude.com/docs/sdks/analytics/browser/browser-sdk-2), you can still use Guides and Surveys but you need to configure the SDK to work with your third-party analytics provider. First, add the SDK to your project using the script tag, or via npm or Yarn as outlined above.
+But, instead of calling `amplitude.add(window.engagement.plugin())`, you'll need to call `init` and `boot`.
 
-{{partial:collapse name="Usign NPM or Yarn"}}
+#### Initialize SDK
 
-Calling `init` is only required when loading Guides and Surveys using NPM or Yarn. If you're using the script installation, skip straight to calling `boot`.
+Calling `init` will fully initialize the bundle and register `engagement` on the global window object.
 
 ```js
-engagement.init(apiKey: string, options: { serverZone: "US" | "EU" }): void
+engagement.init(apiKey: string, options: { serverZone: "US" | "EU", logger: Logger, logLevel: LogLevel }): void
 ```
 
 | Parameter                | Type                                                                                                                         | Description                                                                                                                                                                    |
@@ -68,24 +69,25 @@ engagement.init(apiKey: string, options: { serverZone: "US" | "EU" }): void
 
 After calling this function, you can access `window.engagement` and call the SDK functions. However, Guides and Surveys isn't fully functional until you call `boot`.
 
-{{/partial:collapse}}
+#### Boot User
 
-This initialization code accepts parameters that define the user and any integrations.
+The final step before guides and surveys will show to your end-users is to call `boot`. This method will trigger targeting resolution of your live guides and surveys. It will also establish the connection from the Guides and Surveys SDK to your third-party analytics provider. It is important to call this method only once for a given user session unless you want to change the active user.
+
 
 
 ```js
 engagement.boot(options: BootOptions): Promise<void>
 ```
 
-| Parameter              | Type                           | Description                                                             |
-| ---------------------- | ------------------------------ | ----------------------------------------------------------------------- |
-| `options.user`         | `EndUser` or `(() => EndUser)` | Required. User information or a function that returns user information. |
-| `options.integrations` | `Array<Integration>`           | Optional. An array of integrations for tracking events.                 |
+| Parameter              | Type                           | Description                                                                                                                               |
+| ---------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `options.user`         | `EndUser` or `(() => EndUser)` | Required. User information or a function that returns user information.                                                                   |
+| `options.integrations` | `Array<Integration>`           | Optional. An array of integrations for tracking events. Enables sending Guides and Surveys events to your third-party Analytics provider. |
 
 ```js
 await window.engagement.boot({
   user: {
-    // Guides and Surveys requires either user_id or device_id for user identification
+    // Guides and Surveys requires at least one of user_id or device_id for user identification
     user_id: 'USER_ID', //[tl! ~~:1]
     device_id: 'DEVICE_ID',
     user_properties: {},
@@ -99,6 +101,14 @@ await window.engagement.boot({
   ],
 });
 ```
+
+Finally, if you want to use *On event tracked* [triggers](/docs/guides-and-surveys/guides/guides/setup-and-target#triggers), you need to forward events from your third-party analytics provider to Guides and Surveys. These events are not sent to the server.
+
+```js
+analytics.on('track', (event, properties, options) => { // Example for Segment Analytics
+  window.engagement.forwardEvent({ event_type: event, event_properties: properties});
+});
+
 
 
 {{partial:collapse name="Initialize with Segment analytics"}}
@@ -237,18 +247,11 @@ If the response is `undefined`, Guides and Surveys isn't installed properly.
 
 #### Content Security Policy (CSP)
 
-If your organization has a strict Content Security Policy (CSP), Guides and Surveys requires some additions to ensure smooth operation.
-
-When you use the Amplitude Browser SDK 2 for analytics, add the following items to your CSP:
+If your organization has a strict Content Security Policy (CSP), Guides and Surveys requires some additions to ensure smooth operation. Add the following CSP directives to your policy:
 
 ```text
 script-src: https://*.amplitude.com;
 connect-src: https://*.amplitude.com;
-```
-
-Regardless of the analytics provider you use, Guides and Surveys requires the following additions:
-
-```text
 img-src: https://*.amplitude.com;
 media-src: https://*.amplitude.com;
 style-src: https://*.amplitude.com;
@@ -257,7 +260,7 @@ style-src: https://*.amplitude.com;
 
 ## Manage themes
 
-Configure the visual theme that displays to the user.
+Configure the visual theme mode if your app supports light and dark modes.
 
 ```js
 engagement.setThemeMode(mode: ThemeMode): void
@@ -288,7 +291,7 @@ engagement.setRouter(routerFn: (url: string) => void): void
 
 | Parameter  | Type                    | Description                                           |
 | ---------- | ----------------------- | ----------------------------------------------------- |
-| `routerRn` | `(url: string) => void` | Required. A function that handles changes to the URL. |
+| `routerFn` | `(url: string) => void` | Required. A function that handles changes to the URL. |
 
 ```js
 // React Router v6 implementation
@@ -318,7 +321,7 @@ engagement.gs.reset(key: string, stepIndex?: number)
 
 ## List
 
-Retrieve a list of visible guides or surveys
+Retrieve a list of all live guides and surveys that are known to the SDK along with their status.
 
 ```js
 engagement.gs.list(): Array<GuideOrSurvey>
@@ -335,7 +338,7 @@ interface GuideOrSuvey {
 
 ## Show
 
-Display a specific guide or survey.
+Display a specific guide or survey. This will ignore any targeting rules and limits except for page targeting.
 
 ```js
 engagement.gs.show(key: string, stepIndex?: number): void
@@ -348,15 +351,15 @@ engagement.gs.show(key: string, stepIndex?: number): void
 
 ## Forward event
 
-Trigger Guides and Surveys programmatically.
+Forwared third-party Analytics events to the Guides and Surveys SDK to trigger guides and surveys that use the `*On event tracked*` [trigger](/docs/guides-and-surveys/guides/guides/setup-and-target#triggers).
 
 ```js
 engagement.forwardEvent(event: Event): void
 ```
 
-| Parameter | Type  | Description                                                                                                             |
-| --------- | ----- | ----------------------------------------------------------------------------------------------------------------------- |
-| `event`   | Event | Required. An [event](/docs/sdks/analytics/browser/browser-sdk-2#track-an-event) object that launches a guide or survey. |
+| Parameter | Type  | Description                                                                                                                                            |
+| --------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `event`   | Event | Required. An [event](/docs/sdks/analytics/browser/browser-sdk-2#track-an-event) object. It will trigger a guide or survey if its `event_type` matches. |
 
 
 ## Close all

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -50,12 +50,12 @@ amplitude.add(engagementPlugin());
 
 ### Third-party analytics provider
 
-If you don't use the Amplitude Analytics [Browser SDK 2](https://amplitude.com/docs/sdks/analytics/browser/browser-sdk-2), you can still use Guides and Surveys but you need to configure the SDK to work with your third-party analytics provider. First, add the SDK to your project using the script tag, or via npm or Yarn as outlined above.
-But, instead of calling `amplitude.add(window.engagement.plugin())`, you'll need to call `init` and `boot`.
+If you don't use the Amplitude Analytics [Browser SDK 2](https://amplitude.com/docs/sdks/analytics/browser/browser-sdk-2), you can still use Guides and Surveys but you need to configure the SDK to work with your third-party analytics provider. First, add the SDK to your project using the script tag, or through npm or Yarn as outlined above.
+But, instead of calling `amplitude.add(window.engagement.plugin())`, you need to call `init` and `boot`.
 
 #### Initialize SDK
 
-Calling `init` will fully initialize the bundle and register `engagement` on the global window object.
+Calling `init` fully initializes the bundle and registers `engagement` on the global window object.
 
 ```js
 engagement.init(apiKey: string, options: { serverZone: "US" | "EU", logger: Logger, logLevel: LogLevel }): void
@@ -70,9 +70,9 @@ engagement.init(apiKey: string, options: { serverZone: "US" | "EU", logger: Logg
 
 After calling this function, you can access `window.engagement` and call the SDK functions. However, Guides and Surveys isn't fully functional until you call `boot`.
 
-#### Boot User
+#### Boot user
 
-The final step before guides and surveys will show to your end-users is to call `boot`. This method will trigger targeting resolution of your live guides and surveys. It will also establish the connection from the Guides and Surveys SDK to your third-party analytics provider. It is important to call this method only once for a given user session unless you want to change the active user.
+The final step before guides and surveys can show to your end-users is to call `boot`. This method triggers targeting resolution of your live guides and surveys. It also establishes the connection from the Guides and Surveys SDK to your third-party analytics provider. This method should be called only once for a given session unless you want to change the active user.
 
 
 
@@ -322,7 +322,7 @@ engagement.gs.reset(key: string, stepIndex?: number)
 
 ## List
 
-Retrieve a list of all live guides and surveys that are known to the SDK along with their status.
+Retrieve a list of all live guides and surveys along with their status.
 
 ```js
 engagement.gs.list(): Array<GuideOrSurvey>

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -7,6 +7,7 @@ updated_by: 0c3a318b-936a-4cbd-8fdf-771a90c297f0
 updated_at: 1738949573
 landing_blurb: 'Ensure your site or application is ready for Guides and Surveys.'
 ---
+
 Amplitude's Guides and Surveys SDK enables you to deploy [Guides and Surveys](/docs/guides-and-surveys) on your website or application.
 
 ## Install the SDK
@@ -108,7 +109,7 @@ Finally, if you want to use *On event tracked* [triggers](/docs/guides-and-surve
 analytics.on('track', (event, properties, options) => { // Example for Segment Analytics
   window.engagement.forwardEvent({ event_type: event, event_properties: properties});
 });
-
+```
 
 
 {{partial:collapse name="Initialize with Segment analytics"}}

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -362,7 +362,7 @@ engagement.forwardEvent(event: Event): void
 
 | Parameter | Type  | Description                                                                                                                                            |
 | --------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `event`   | Event | Required. An [event](/docs/sdks/analytics/browser/browser-sdk-2#track-an-event) object. It will trigger a guide or survey if its `event_type` matches. |
+| `event`   | Event | Required. An [event](/docs/sdks/analytics/browser/browser-sdk-2#track-an-event) object. It triggers a guide or survey if its `event_type` matches. |
 
 
 ## Close all

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -122,6 +122,8 @@ First, the initialization code requires you to map the `user_id` and `device_id`
 {{partial:tab name="script"}}
 Make sure you've added the Engagement script tag to your site before continuing.
 ```js
+window.engagement.init("API_KEY", { serverZone: "US" });
+
 analytics.ready(() => {
   await window.engagement.boot({
     user: {

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -50,7 +50,7 @@ amplitude.add(engagementPlugin());
 
 ### Third-party analytics provider
 
-If you don't use the Amplitude Analytics [Browser SDK 2](https://amplitude.com/docs/sdks/analytics/browser/browser-sdk-2), you can still use Guides and Surveys but you need to configure the SDK to work with your third-party analytics provider. First, add the SDK to your project using the script tag, or through npm or Yarn as outlined above.
+If you don't use the Amplitude Analytics [Browser SDK 2](/docs/sdks/analytics/browser/browser-sdk-2), you can still use Guides and Surveys but you need to configure the SDK to work with your third-party analytics provider. First, add the SDK to your project using the script tag, or through npm or Yarn as outlined above.
 But, instead of calling `amplitude.add(window.engagement.plugin())`, you need to call `init` and `boot`.
 
 #### Initialize SDK

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -53,7 +53,7 @@ amplitude.add(engagementPlugin());
 If you don't use the Amplitude Analytics [Browser SDK 2](/docs/sdks/analytics/browser/browser-sdk-2), you can still use Guides and Surveys but you need to configure the SDK to work with your third-party analytics provider. First, add the SDK to your project using the script tag, or through npm or Yarn as outlined above.
 But, instead of calling `amplitude.add(window.engagement.plugin())`, you need to call `init` and `boot`.
 
-#### Initialize SDK
+#### Initialize the SDK
 
 Call `init` to  fully initialize the bundle and register `engagement` on the global window object.
 


### PR DESCRIPTION
Make documentation around `boot` and `init` more explicit and tweak descriptions for a couple SDK methods.