### PR TITLE
chore: update doc for Amplitude-Swift

### DIFF
--- a/content/collections/instrumentation/en/sdk-quickstart.md
+++ b/content/collections/instrumentation/en/sdk-quickstart.md
@@ -497,7 +497,7 @@ sdk:
           1. Add the dependency to your `Podfile`:
 
               ```bash
-              pod 'AmplitudeSwift', '~> 1.0.0'
+              pod 'AmplitudeSwift', '~> 1.0'
               ```
           2. Run `pod install` in the project directory.
       -
@@ -515,7 +515,7 @@ sdk:
         instructions: |-
           Add the following line to your `Cartfile`.
           ```bash
-          github "amplitude/Amplitude-Swift" ~> 1.0.0
+          github "amplitude/Amplitude-Swift" ~> 1.0
           ```
           Check out the [Carthage docs](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) for more info.
     type: intro

--- a/content/collections/ios_sdk/en/ampli-for-ios-swift-sdk.md
+++ b/content/collections/ios_sdk/en/ampli-for-ios-swift-sdk.md
@@ -101,7 +101,7 @@ Install the Amplitude Analytics iOS SDK with CocoaPods, Carthage, or Swift Packa
 {{partial:tab name="Carthage"}}
 Add the following line to your `Cartfile`.
 ```bash
-github "amplitude/
+github "amplitude/Amplitude-Swift" ~> 1.0
 ```
 Check out the [Carthage docs](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) for more info.
 {{/partial:tab}}

--- a/content/collections/ios_sdk/en/ampli-for-ios-swift-sdk.md
+++ b/content/collections/ios_sdk/en/ampli-for-ios-swift-sdk.md
@@ -27,7 +27,7 @@ Amplitude Data supports tracking analytics events from iOS apps written in Swift
 1. [Install the Amplitude SDK](#install-the-amplitude-sdk)
 
     ```bash
-    pod 'AmplitudeSwift', '~> 1.0.0'
+    pod 'AmplitudeSwift', '~> 1.0'
     ```
 
 2. [Install the Ampli CLI](#install-the-ampli-cli)
@@ -87,7 +87,7 @@ Install the Amplitude Analytics iOS SDK with CocoaPods, Carthage, or Swift Packa
 1. Add the dependency to your `Podfile`:
 
     ```bash
-    pod 'AmplitudeSwift', '~> 1.0.0'
+    pod 'AmplitudeSwift', '~> 1.0'
     ```
 2. Run `pod install` in the project directory.
 {{/partial:tab}}
@@ -101,7 +101,7 @@ Install the Amplitude Analytics iOS SDK with CocoaPods, Carthage, or Swift Packa
 {{partial:tab name="Carthage"}}
 Add the following line to your `Cartfile`.
 ```bash
-github "amplitude/Amplitude-Swift" ~> 1.0.0
+github "amplitude/
 ```
 Check out the [Carthage docs](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) for more info.
 {{/partial:tab}}

--- a/content/collections/ios_sdk/en/ios-swift-sdk.md
+++ b/content/collections/ios_sdk/en/ios-swift-sdk.md
@@ -28,7 +28,7 @@ This is the official documentation for the Amplitude Analytics iOS SDK.
 1. Add the dependency to your `Podfile`:
 
     ```bash
-    pod 'AmplitudeSwift', '~> 1.0.0'
+    pod 'AmplitudeSwift', '~> 1.0'
     ```
 2. Run `pod install` in the project directory.
 {{/partial:tab}}
@@ -42,7 +42,7 @@ This is the official documentation for the Amplitude Analytics iOS SDK.
 {{partial:tab name="Carthage"}}
 Add the following line to your `Cartfile`.
 ```bash
-github "amplitude/Amplitude-Swift" ~> 1.0.0
+github "amplitude/Amplitude-Swift" ~> 1.0
 ```
 Check out the [Carthage docs](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) for more info.
 {{/partial:tab}}
@@ -80,7 +80,7 @@ Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
 | `loggerProvider`               | Implements a custom `loggerProvider` class from the Logger, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment. | `ConsoleLogger`                          |
 | `flushIntervalMillis`          | The amount of time SDK will attempt to upload the unsent events to the server or reach `flushQueueSize` threshold.                                                                                          | `30000`                                  |
 | `flushQueueSize`               | SDK will attempt to upload once unsent event count exceeds the event upload threshold or reach `flushIntervalMillis` interval.                                                                              | `30`                                     |
-| `flushMaxRetries`              | Maximum retry times.                                                                                                                                                                                        | `5`                                      |
+| `flushMaxRetries`              | Maximum retry times.                                                                                                                                                                                        | `6`                                      |
 | `minIdLength`                  | The minimum length for user id or device id.                                                                                                                                                                | `5`                                      |
 | `partnerId`                    | The partner id for partner integration.                                                                                                                                                                     | `nil`                                    |
 | `identifyBatchIntervalMillis`  | The amount of time SDK will attempt to batch intercepted identify events.                                                                                                                                   | `30000`                                  |

--- a/content/globals/en/sdk_versions.yaml
+++ b/content/globals/en/sdk_versions.yaml
@@ -1,7 +1,7 @@
 browser: 2.11.12
 android: 1.19.4
 node: 1.3.6
-ios: 1.11.3
+ios: 1.11.9
 java: 1.12.4
 react_native: 1.1.7
 flutter: 3.16.7


### PR DESCRIPTION
- `flushMaxRetries` was not actually used in previous versions of Amplitude-Swift. Version 1.11.9 fixed this issue and changed the default value from `5` to `6`.
- Change installation suggestion to `~> 1.0`. The old suggestion only matches versions at 1.0.x.