### PR TITLE
update Android SDKs to reflect the recent changes for location tracking

### DIFF
--- a/content/collections/android_sdk/en/android-kotlin-sdk.md
+++ b/content/collections/android_sdk/en/android-kotlin-sdk.md
@@ -1227,7 +1227,10 @@ To set the device, see to [custom device ID](#custom-device-id).
 
 Amplitude converts the IP of a user event into a location (GeoIP lookup) by default. This information may be overridden by an app's own tracking solution or user data.
 
-The SDK disables location tracking by default. Call `enableLocationListening()` to track location data. When enabled, Amplitude uses Android location services (if available) to add specific coordinates (longitude and latitude) to logged events. Call `disableLocationListening()` at any time to disable location tracking.
+{{partial:admonition type="note" heading="Location tracking in version 1.20.7+"}}
+As of version 1.20.7, the SDK disables location tracking by default. Call `enableLocationListening()` to track location data. When enabled, Amplitude uses Android location services (if available) to add specific coordinates (longitude and latitude) to logged events. Call `disableLocationListening()` at any time to disable location tracking.
+{{/partial:admonition}}
+
 
 {{partial:tabs tabs="Kotlin, Java"}}
 {{partial:tab name="Kotlin"}}

--- a/content/collections/android_sdk/en/android-kotlin-sdk.md
+++ b/content/collections/android_sdk/en/android-kotlin-sdk.md
@@ -1227,7 +1227,7 @@ To set the device, see to [custom device ID](#custom-device-id).
 
 Amplitude converts the IP of a user event into a location (GeoIP lookup) by default. This information may be overridden by an app's own tracking solution or user data.
 
-By default, Amplitude can use Android location service (if available) to add the specific coordinates (longitude and latitude) for the location from which an event is logged. Control this behavior by enable / disable location listening during the initialization.
+Location tracking is disabled by default in the SDK. If you want to track location data, you can enable it by calling `enableLocationListening()`. This allows Amplitude to use Android location services (if available) to add specific coordinates (longitude and latitude) for the location from which an event is logged. You can also disable location tracking at any time by calling `disableLocationListening()`.
 
 {{partial:tabs tabs="Kotlin, Java"}}
 {{partial:tab name="Kotlin"}}

--- a/content/collections/android_sdk/en/android-kotlin-sdk.md
+++ b/content/collections/android_sdk/en/android-kotlin-sdk.md
@@ -1227,7 +1227,7 @@ To set the device, see to [custom device ID](#custom-device-id).
 
 Amplitude converts the IP of a user event into a location (GeoIP lookup) by default. This information may be overridden by an app's own tracking solution or user data.
 
-Location tracking is disabled by default in the SDK. If you want to track location data, you can enable it by calling `enableLocationListening()`. This allows Amplitude to use Android location services (if available) to add specific coordinates (longitude and latitude) for the location from which an event is logged. You can also disable location tracking at any time by calling `disableLocationListening()`.
+The SDK disables location tracking by default. Call `enableLocationListening()` to track location data. When enabled, Amplitude uses Android location services (if available) to add specific coordinates (longitude and latitude) to logged events. Call `disableLocationListening()` at any time to disable location tracking.
 
 {{partial:tabs tabs="Kotlin, Java"}}
 {{partial:tab name="Kotlin"}}

--- a/content/collections/android_sdk/en/android-sdk.md
+++ b/content/collections/android_sdk/en/android-sdk.md
@@ -1021,7 +1021,9 @@ client.setDeviceId("DEVICE-ID");
 
 Amplitude converts the IP of a user event into a location (GeoIP lookup) by default. This information may be overridden by an app's own tracking solution or user data.
 
-The SDK disables location tracking by default. Call `enableLocationListening()` to track location data. When enabled, Amplitude uses Android location services (if available) to add specific coordinates (longitude and latitude) to logged events. Call `disableLocationListening()` at any time to disable location tracking.
+{{partial:admonition type="note" heading="Location tracking in version 1.20.7+"}}
+As of version 1.20.7, the SDK disables location tracking by default. Call `enableLocationListening()` to track location data. When enabled, Amplitude uses Android location services (if available) to add specific coordinates (longitude and latitude) to logged events. Call `disableLocationListening()` at any time to disable location tracking.
+{{/partial:admonition}}
 
 ```java
 client.enableLocationListening();

--- a/content/collections/android_sdk/en/android-sdk.md
+++ b/content/collections/android_sdk/en/android-sdk.md
@@ -1021,8 +1021,8 @@ client.setDeviceId("DEVICE-ID");
 
 Amplitude converts the IP of a user event into a location (GeoIP lookup) by default. This information may be overridden by an app's own tracking solution or user data.
 
-{{partial:admonition type="note" heading="Location tracking in version 1.20.7+"}}
-As of version 1.20.7, the SDK disables location tracking by default. Call `enableLocationListening()` to track location data. When enabled, Amplitude uses Android location services (if available) to add specific coordinates (longitude and latitude) to logged events. Call `disableLocationListening()` at any time to disable location tracking.
+{{partial:admonition type="note" heading="Location tracking in version v2.40.3+"}}
+As of version v2.40.3, the SDK disables location tracking by default. Call `enableLocationListening()` to track location data. When enabled, Amplitude uses Android location services (if available) to add specific coordinates (longitude and latitude) to logged events. Call `disableLocationListening()` at any time to disable location tracking.
 {{/partial:admonition}}
 
 ```java

--- a/content/collections/android_sdk/en/android-sdk.md
+++ b/content/collections/android_sdk/en/android-sdk.md
@@ -1021,7 +1021,7 @@ client.setDeviceId("DEVICE-ID");
 
 Amplitude converts the IP of a user event into a location (GeoIP lookup) by default. This information may be overridden by an app's own tracking solution or user data.
 
-Location tracking is disabled by default in the SDK. If you want to track location data, you can enable it by calling `enableLocationListening()`. This allows Amplitude to use Android location services (if available) to add specific coordinates (longitude and latitude) for the location from which an event is logged. You can also disable location tracking at any time by calling `disableLocationListening()`.
+The SDK disables location tracking by default. Call `enableLocationListening()` to track location data. When enabled, Amplitude uses Android location services (if available) to add specific coordinates (longitude and latitude) to logged events. Call `disableLocationListening()` at any time to disable location tracking.
 
 ```java
 client.enableLocationListening();

--- a/content/collections/android_sdk/en/android-sdk.md
+++ b/content/collections/android_sdk/en/android-sdk.md
@@ -1021,7 +1021,7 @@ client.setDeviceId("DEVICE-ID");
 
 Amplitude converts the IP of a user event into a location (GeoIP lookup) by default. This information may be overridden by an app's own tracking solution or user data.
 
-By default, Amplitude can use Android location service (if available) to add the specific coordinates (longitude and latitude) for the location from which an event is logged. Control this behavior by calling the `enableLocationListening` or `disableLocationListening` method after initializing.
+Location tracking is disabled by default in the SDK. If you want to track location data, you can enable it by calling `enableLocationListening()`. This allows Amplitude to use Android location services (if available) to add specific coordinates (longitude and latitude) for the location from which an event is logged. You can also disable location tracking at any time by calling `disableLocationListening()`.
 
 ```java
 client.enableLocationListening();


### PR DESCRIPTION
We're now defaulting location tracking to false for Android to address the privacy issue flagged by Google (see [JIRA ticket](https://amplitude.atlassian.net/browse/AMP-127891)).

This update is for making sure that clients are informed of this behavior change if they still want to opt-in to the previous behavior.

- Legacy - https://github.com/amplitude/Amplitude-Android/releases/tag/v2.40.3
- Kotlin - https://github.com/amplitude/Amplitude-Kotlin/releases/tag/v1.20.7
