### PR TITLE
AMP-131331 update web unified SDK 

### DIFF
--- a/content/collections/browser_sdk/en/browser-unified-sdk.md
+++ b/content/collections/browser_sdk/en/browser-unified-sdk.md
@@ -112,6 +112,7 @@ initAll('YOUR_API_KEY', {
   // Session Replay options
   sessionReplay: {
     // Session Replay configuration options
+    sampleRate: 1 // To enable session replay
   },
   
   // Experiment options
@@ -134,7 +135,8 @@ All options from `@amplitude/analytics-browser` are supported. See the [Analytic
 
 ### Session Replay options
 
-All options from `@amplitude/plugin-session-replay-browser` are supported. See the [Session Replay documentation](/docs/session-replay/session-replay-standalone-sdk#configuration) for details.
+All options from `@amplitude/plugin-session-replay-browser` are supported. See the [Session Replay documentation](/docs/session-replay/session-replay-plugin#configuration) for details. Set `config.sessionReplay.sampleRate` to a non-zero value to enable session replay. 
+
 
 ### Experiment options
 

--- a/content/collections/browser_sdk/en/browser-unified-sdk.md
+++ b/content/collections/browser_sdk/en/browser-unified-sdk.md
@@ -135,7 +135,9 @@ All options from `@amplitude/analytics-browser` are supported. See the [Analytic
 
 ### Session Replay options
 
-All options from `@amplitude/plugin-session-replay-browser` are supported. See the [Session Replay documentation](/docs/session-replay/session-replay-plugin#configuration) for details. Set `config.sessionReplay.sampleRate` to a non-zero value to enable session replay. 
+The Unified Browser SDK supports all options from `@amplitude/plugin-session-replay-browser`. See the [Session Replay Plugin documentation](/docs/session-replay/session-replay-plugin#configuration) for more information. Set `config.sessionReplay.sampleRate` to a non-zero value to enable session replay. 
+
+Sample Rate controls the rate at which Amplitude captures session replays. For example, if you set `config.sessionReplay.sampleRate` to `0.5`, Session Replay captures roughly half of all sessions.
 
 
 ### Experiment options


### PR DESCRIPTION
Set sample rate to 1 in the example to help customers enable session replay. 