### PR TITLE
Clarify non-browser sdk's

### DIFF
--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -53,9 +53,9 @@ For additional configuration, supply `InitOptions` to the `plugin` function. See
 
 
 
-### Third-party analytics provider
+### Other Amplitude SDK's and third-party analytics providers 
 
-If you don't use the Amplitude Analytics [Browser SDK 2](/docs/sdks/analytics/browser/browser-sdk-2), you can still use Guides and Surveys but you need to configure the SDK to work with your third-party analytics provider. First, add the SDK to your project using the script tag, or through npm or Yarn as outlined above.
+If you don't use the Amplitude Analytics [Browser SDK 2](/docs/sdks/analytics/browser/browser-sdk-2), you can still use Guides and Surveys but you need to configure the SDK to work with your other Amplitude Analytics SDK or third-party analytics provider. First, add the SDK to your project using the script tag, or through npm or Yarn as outlined above.
 But, instead of calling `amplitude.add(window.engagement.plugin())`, you need to call `init` and `boot`.
 
 #### Initialize the SDK


### PR DESCRIPTION
We've had some feedback that people don't know where to look when they use an Amplitude Analytics SDK that's not the browser sdk v2, so here we're clarifying the section title and some of the detail copy