### PR TITLE
AMP-132981 [SnowflakeImport] Update developer docs to reflect ABORT_DETACHED_QUERY session-level behavior

### DIFF
--- a/content/collections/source-catalog/en/snowflake.md
+++ b/content/collections/source-catalog/en/snowflake.md
@@ -45,7 +45,7 @@ Amplitude's Data Warehouse Import sometimes processes events in parallel, so tim
 {{/partial:admonition}}
 
 {{partial:admonition type="note" heading="Long running queries"}}
-To ensure that your import queries aren't canceled, set `ABORT_DETACHED_QUERY` to `FALSE` at the account level.
+To ensure your import queries aren’t canceled, we automatically set `ABORT_DETACHED_QUERY = FALSE` at the session level.
 {{/partial:admonition}}
 
 ## Add and configure the Snowflake source
@@ -547,7 +547,7 @@ When a Snowflake query times out, Amplitude automatically retries the query usin
 
 Amplitude attempts up to 8 retries (9 total attempts including the initial query) before marking an import job as failed. Each retry attempt starts fresh, ensuring a consistent approach to retrieving your data.
 
-### Why should I set ABORT_DETACHED_QUERY to FALSE?
+### Why do we set ABORT_DETACHED_QUERY to FALSE?
 
 Setting `ABORT_DETACHED_QUERY = FALSE` at the account level prevents Snowflake from silently canceling import queries that run longer than 5 minutes. Without this setting:
 

--- a/content/collections/source-catalog/en/snowflake.md
+++ b/content/collections/source-catalog/en/snowflake.md
@@ -45,7 +45,7 @@ Amplitude's Data Warehouse Import sometimes processes events in parallel, so tim
 {{/partial:admonition}}
 
 {{partial:admonition type="note" heading="Long running queries"}}
-To ensure your import queries aren’t canceled, we automatically set `ABORT_DETACHED_QUERY = FALSE` at the session level.
+To ensure your import queries aren’t canceled, Amplitude sets `ABORT_DETACHED_QUERY = FALSE` at the session level.
 {{/partial:admonition}}
 
 ## Add and configure the Snowflake source
@@ -547,7 +547,7 @@ When a Snowflake query times out, Amplitude automatically retries the query usin
 
 Amplitude attempts up to 8 retries (9 total attempts including the initial query) before marking an import job as failed. Each retry attempt starts fresh, ensuring a consistent approach to retrieving your data.
 
-### Why do we set ABORT_DETACHED_QUERY to FALSE?
+### Why is ABORT_DETACHED_QUERY set to FALSE?
 
 Setting `ABORT_DETACHED_QUERY = FALSE` at the account level prevents Snowflake from silently canceling import queries that run longer than 5 minutes. Without this setting:
 


### PR DESCRIPTION
This PR updates the developer documentation for Snowflake import to reflect the recent change in how we handle ABORT_DETACHED_QUERY.
* Clarified that ABORT_DETACHED_QUERY = FALSE is now automatically set at the session level during import.
* Removed outdated instructions suggesting customers set this manually at the account level.
