### PR TITLE
Update sdk.md

### DIFF
--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -53,7 +53,7 @@ For additional configuration, supply `InitOptions` to the `plugin` function. See
 
 
 
-### Other Amplitude SDK's and third-party analytics providers 
+### Other Amplitude SDK's and third-party analytics providers
 
 If you don't use the Amplitude Analytics [Browser SDK 2](/docs/sdks/analytics/browser/browser-sdk-2), you can still use Guides and Surveys but you need to configure the SDK to work with your other Amplitude Analytics SDK or third-party analytics provider. First, add the SDK to your project using the script tag, or through npm or Yarn as outlined above.
 But, instead of calling `amplitude.add(window.engagement.plugin())`, you need to call `init` and `boot`.
@@ -63,7 +63,7 @@ But, instead of calling `amplitude.add(window.engagement.plugin())`, you need to
 Call `init` to  fully initialize the bundle and register `engagement` on the global window object.
 
 ```js
-engagement.init(apiKey: string, options: { serverZone: "US" | "EU", serverUrl: string, cdnUrl: string, logger: Logger, logLevel: LogLevel, locale: string }): void
+engagement.init(apiKey: string, options: { serverZone: "US" | "EU", serverUrl: string, cdnUrl: string, logger: Logger, logLevel: LogLevel, locale: string, nonce: string }): void
 ```
 
 | Parameter                | Type                                                                                                                         | Description                                                                                                                                                                    |
@@ -75,6 +75,7 @@ engagement.init(apiKey: string, options: { serverZone: "US" | "EU", serverUrl: s
 | `initOptions.logger`     | [Logger interface](https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-types/src/logger.ts#L1-L8) | Optional. Sets a custom logging provider class. Default: [Amplitude Logger](https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-core/src/logger.ts) |
 | `initOptions.logLevel`   | `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`.                            | Optional. Sets the log level. Default: `LogLevel.Warn`                                                                                                                         |
 | `initOptions.locale`     | `string`                                                                                                                     | Optional. Sets the locale for [localization](/docs/guides-and-surveys/sdk#localization). Default: `undefined`. Not setting a language means the default language is used.      |
+| `initOptions.nonce`      | `string`                                                                                                                     | Optional. Sets a nonce value for Content Security Policy (CSP) compliance. This allows inline styles required by Guides and Surveys to be executed when CSP is enabled. Default: `undefined` |
 
 ##### Example: Basic initialization
 
@@ -93,6 +94,16 @@ For [proxy setups](/docs/guides-and-surveys/proxy), specify both `serverUrl` and
 engagement.init("YOUR_API_KEY", {
   serverUrl: "https://your-proxy-domain.cloudfront.net",
   cdnUrl: "https://your-proxy-domain.cloudfront.net"
+});
+```
+
+##### Example: Initialization with CSP nonce
+
+For Content Security Policy (CSP) compliance, include a nonce value:
+
+```js
+engagement.init("YOUR_API_KEY", {
+  nonce: "YOUR_NONCE"
 });
 ```
 
@@ -117,7 +128,7 @@ engagement.boot(options: BootOptions): Promise<void>
 await window.engagement.boot({
   user: {
     // Guides and Surveys requires at least one of user_id or device_id for user identification
-    user_id: 'USER_ID', 
+    user_id: 'USER_ID',
     device_id: 'DEVICE_ID',
     user_properties: {},
   },
@@ -299,6 +310,14 @@ connect-src: https://*.amplitude.com;
 img-src: https://*.amplitude.com;
 media-src: https://*.amplitude.com;
 style-src: https://*.amplitude.com;
+```
+
+For environments with stricter CSP requirements that block inline styles, you can use the `nonce` parameter during initialization. This allows Guides and Surveys to execute necessary inline styles by including your CSP nonce value:
+
+```js
+engagement.init("YOUR_API_KEY", {
+  nonce: "YOUR_NONCE"
+});
 ```
 
 


### PR DESCRIPTION
## PR Summary

**Add `nonce` parameter support to Guides and Surveys SDK documentation**
This update helps developers implement Guides and Surveys in environments with strict CSP policies by providing a way to whitelist necessary inline styles.

### Changes Made:
- Added `nonce` parameter to `engagement.init()` function signature
- Added parameter documentation explaining CSP compliance usage
- Added example showing nonce initialization
- Enhanced CSP section with guidance on using nonce for stricter CSP requirements

### What's New:
- **CSP Support**: The SDK now supports a `nonce` parameter for Content Security Policy compliance
- **Inline Styles**: Enables execution of required inline styles when CSP blocks them
- **Usage**: Pass `nonce: "YOUR_NONCE"` in the init options object

### Files Modified:
- `content/collections/guides_and_surveys/en/sdk.md`

