### PR TITLE
[wormhole] add segment traits sync to example

### DIFF
--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -66,16 +66,16 @@ Call `init` to  fully initialize the bundle and register `engagement` on the glo
 engagement.init(apiKey: string, options: { serverZone: "US" | "EU", serverUrl: string, cdnUrl: string, logger: Logger, logLevel: LogLevel, locale: string, nonce: string }): void
 ```
 
-| Parameter                | Type                                                                                                                         | Description                                                                                                                                                                    |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `apiKey`                 | `string`                                                                                                                     | Required. API key of the Amplitude project you want to use.                                                                                                                    |
-| `initOptions.serverZone` | `EU` or `US`                                                                                                                 | Optional. Sets the Amplitude server zone. Set this to EU for Amplitude projects created in EU data center. Default: `US`                                                       |
+| Parameter                | Type                                                                                                                         | Description                                                                                                                                                                                    |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apiKey`                 | `string`                                                                                                                     | Required. API key of the Amplitude project you want to use.                                                                                                                                    |
+| `initOptions.serverZone` | `EU` or `US`                                                                                                                 | Optional. Sets the Amplitude server zone. Set this to EU for Amplitude projects created in EU data center. Default: `US`                                                                       |
 | `initOptions.serverUrl`  | `string`                                                                                                                     | Optional. Sets a custom server URL for API requests. Useful for [proxy setups](/docs/guides-and-surveys/proxy). Default: `https://gs.amplitude.com` (US) or `https://gs.eu.amplitude.com` (EU) |
 | `initOptions.cdnUrl`     | `string`                                                                                                                     | Optional. Sets a custom CDN URL for static assets. Useful for [proxy setups](/docs/guides-and-surveys/proxy). Default: `https://cdn.amplitude.com` (US) or `https://cdn.eu.amplitude.com` (EU) |
-| `initOptions.logger`     | [Logger interface](https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-types/src/logger.ts#L1-L8) | Optional. Sets a custom logging provider class. Default: [Amplitude Logger](https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-core/src/logger.ts) |
-| `initOptions.logLevel`   | `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`.                            | Optional. Sets the log level. Default: `LogLevel.Warn`                                                                                                                         |
-| `initOptions.locale`     | `string`                                                                                                                     | Optional. Sets the locale for [localization](/docs/guides-and-surveys/sdk#localization). Default: `undefined`. Not setting a language means the default language is used.      |
-| `initOptions.nonce`      | `string`                                                                                                                     | Optional. Sets a nonce value for Content Security Policy (CSP) compliance. This allows inline styles required by Guides and Surveys to be executed when CSP is enabled. Default: `undefined` |
+| `initOptions.logger`     | [Logger interface](https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-types/src/logger.ts#L1-L8) | Optional. Sets a custom logging provider class. Default: [Amplitude Logger](https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-core/src/logger.ts)                 |
+| `initOptions.logLevel`   | `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`.                            | Optional. Sets the log level. Default: `LogLevel.Warn`                                                                                                                                         |
+| `initOptions.locale`     | `string`                                                                                                                     | Optional. Sets the locale for [localization](/docs/guides-and-surveys/sdk#localization). Default: `undefined`. Not setting a language means the default language is used.                      |
+| `initOptions.nonce`      | `string`                                                                                                                     | Optional. Sets a nonce value for Content Security Policy (CSP) compliance. This allows inline styles required by Guides and Surveys to be executed when CSP is enabled. Default: `undefined`   |
 
 ##### Example: Basic initialization
 
@@ -119,9 +119,9 @@ The final step before guides and surveys can show to your end-users is to call `
 engagement.boot(options: BootOptions): Promise<void>
 ```
 
-| Parameter              | Type                           | Description                                                                                                                               |
-| ---------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `options.user`         | `EndUser` or `(() => EndUser)` | Required. User information or a function that returns user information.                                                                   |
+| Parameter              | Type                           | Description                                                                                                                                                                                                                                                                                                         |
+| ---------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `options.user`         | `EndUser` or `(() => EndUser)` | Required. User information or a function that returns user information.                                                                                                                                                                                                                                             |
 | `options.integrations` | `Array<Integration>`           | Optional but strongly encouraged. An array of integrations for tracking events. Enables sending Guides and Surveys events to your third-party Analytics provider. These events are necessary to receive guide insights, survey insights, and survey responses to populate as expected. Otherwise, content is empty. |
 
 ```js
@@ -170,7 +170,7 @@ analytics.ready(() => {
       // User Provider: Guides and Surveys requires either user_id or device_id for user identification
       user_id: analytics.user().id(),
       device_id: analytics.user().anonymousId(),
-      user_properties: {},
+      user_properties: analytics.user().traits(),
     },
     integrations: [
       {
@@ -485,9 +485,9 @@ Ensure that user properties load during the current client-side session and befo
 engagement._setUserProperties(userProperties: Record<string, any>): void
 ```
 
-| Parameter        | Type                      | Description                                                                                                                        |
-| ---------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `userProperties` | `Record<string, any>`     | Required. An object that contains user properties as key-value pairs. Reference these properties in guides and surveys content. |
+| Parameter        | Type                  | Description                                                                                                                     |
+| ---------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `userProperties` | `Record<string, any>` | Required. An object that contains user properties as key-value pairs. Reference these properties in guides and surveys content. |
 ### Example
 
 ```js


### PR DESCRIPTION
So it works the same as in experiment: https://github.com/amplitude/experiment-js-client/blob/a7a5545affe60ba841d5025c462343639bb63b43/packages/plugin-segment/src/plugin.ts#L49