### PR TITLE
Remove "web only" for randomize order, other option, and text animation

### DIFF
--- a/content/collections/guides_and_surveys/en/build-a-survey.md
+++ b/content/collections/guides_and_surveys/en/build-a-survey.md
@@ -86,8 +86,8 @@ Click the gear icon in the List block to access more settings.
 | Required     | Enable to require the user to enter a rating.                                                                                                                                                                       |
 | ARIA label   | Provide a label to help screen readers understand the input's purpose.                                                                                                                                              |
 | Multiple choice | Enables users to select more than one option. Changes the block's form elements from radio buttons to checkboxes.
-| Randomize order <br/> {.tag .web .zero} | Randomizes the order in which items appear in the list each time it displays to a user. |
-| "Other" option <br/> {.tag .web .zero} | Provides users the option to select `Other` as a result, and optionally supply a written answer. |
+| Randomize order | Randomizes the order in which items appear in the list each time it displays to a user. |
+| "Other" option  | Provides users the option to select `Other` as a result, and optionally supply a written answer. |
 
 
 ## Setup and target your survey

--- a/content/collections/guides_and_surveys/en/form-factors.md
+++ b/content/collections/guides_and_surveys/en/form-factors.md
@@ -33,7 +33,7 @@ Click the three dot menu to access format settings.
 | Content layout <br/> {.tag .web .zero} | Updates the visual ordering of the guide's content.               |
 | Actions bar <br/> {.tag .web .zero}    | Updates the placement and layout of the guide's buttons.          |
 | Click outside to close                 | Enables users to click or tap outside of the modal to dismiss it. |
-| Text animation <br/> {.tag .web .zero} | Enables the modal's text to animate in with a typewriter effect.  |
+| Text animation                         | Enables the modal's text to animate in with a typewriter effect.  |
 
 
 
@@ -45,13 +45,13 @@ Popovers offer the same customization options as modals.
 
 Click the three dot menu to access format settings.
 
-| Setting                                | Description                                                       |
-| -------------------------------------- | ----------------------------------------------------------------- |
-| Content layout <br/> {.tag .web .zero} | Updates the visual ordering of the guide's content.               |
-| Actions bar <br/> {.tag .web .zero}    | Updates the placement and layout of the guide's buttons.          |
-| Click outside to close                 | Enables users to click or tap outside of the modal to dismiss it. |
-| Z-index <br/> {.tag .web .zero}        | Specify a custom z-index value for the popover.                   |
-| Text animation <br/> {.tag .web .zero} | Enables the modal's text to animate in with a typewriter effect.  |
+| Setting                                | Description                                                        |
+| -------------------------------------- | ------------------------------------------------------------------ |
+| Content layout <br/> {.tag .web .zero} | Updates the visual ordering of the guide's content.                |
+| Actions bar <br/> {.tag .web .zero}    | Updates the placement and layout of the guide's buttons.           |
+| Click outside to close                 | Enables users to click or tap outside of the modal to dismiss it.  |
+| Z-index <br/> {.tag .web .zero}        | Specify a custom z-index value for the popover.                    |
+| Text animation                         | Enables the popover's text to animate in with a typewriter effect. |
 
 
 ### Pin
@@ -70,7 +70,7 @@ Click the three dot menu to access format settings.
 | Actions bar <br/> {.tag .web .zero}      | Updates the placement and layout of the guide's buttons.                                                   |
 | Click outside to close                   | Enables users to click or tap outside of the modal to dismiss it.                                          |
 | Z-index <br/> {.tag .web .zero}          | Specify a custom z-index value for the popover.                                                            |
-| Text animation <br/> {.tag .web .zero}   | Enables the modal's text to animate in with a typewriter effect.                                           |
+| Text animation                           | Enables the pin's text to animate in with a typewriter effect.                                             |
 | Advanced trigger <br/> {.tag .web .zero} | Enables advancing the guide to another step when the the user interacts with the element you specify.      |
 
 
@@ -88,7 +88,7 @@ Tooltips are like pins, but reveal only when a user clicks, taps, or hovers thei
 | Actions bar <br/> {.tag .web .zero}      | Updates the placement and layout of the guide's buttons.                                              |
 | Z-index <br/> {.tag .web .zero}          | Specify a custom z-index value for the popover.                                                       |
 | Pointer                                  | Select the style with which the dialog relates to the marker.                                         |
-| Text animation <br/> {.tag .web .zero}   | Enables the modal's text to animate in with a typewriter effect.                                      |
+| Text animation                           | Enables the tooltip's text to animate in with a typewriter effect.                                     |
 | Advanced trigger <br/> {.tag .web .zero} | Enables advancing the guide to another step when the the user interacts with the element you specify. |
 | Show on                                  | Select the trigger that causes the tooltip to appear.                                                 |
 | Marker                                   | Select the appearance of the marker that launches the tooltip.                                        |
@@ -106,7 +106,7 @@ Banners are full-width blocks that show on either the top or bottom of the page.
 | Sticky <br/> {.tag .web .zero}         | Keeps the banner visible while the user scrolls.                                                             |
 | Display style <br/> {.tag .web .zero}  | Controls the way in which the banner interacts with the page's content. Mobile banners support overlay only. |
 | Z-index <br/> {.tag .web .zero}        | Specify a custom z-index value for the popover.                                                              |
-| Text animation <br/> {.tag .web .zero} | Enables the modal's text to animate in with a typewriter effect.                                             |
+| Text animation                         | Enables the banner's text to animate in with a typewriter effect.                                            |
 
 
 ### Checklist {.tag .web}

--- a/content/collections/guides_and_surveys/en/form-factors.md
+++ b/content/collections/guides_and_surveys/en/form-factors.md
@@ -65,7 +65,7 @@ Click the three dot menu to access format settings.
 | Setting                                  | Description                                                                                                |
 | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | Open by default                          | Enables the pin to open without user interaction. If disabled, users must click or tap the pin to open it. |
-| Show mask <br/> {.tag .web .zero}        | Enables a background mask when the pin is open to help draw the user's focus.                              |
+| Show mask                                | Enables a background mask when the pin is open to help draw the user's focus.                              |
 | Content layout <br/> {.tag .web .zero}   | Updates the visual ordering of the guide's content.                                                        |
 | Actions bar <br/> {.tag .web .zero}      | Updates the placement and layout of the guide's buttons.                                                   |
 | Click outside to close                   | Enables users to click or tap outside of the modal to dismiss it.                                          |

--- a/content/collections/guides_and_surveys/en/guide-overview.md
+++ b/content/collections/guides_and_surveys/en/guide-overview.md
@@ -19,6 +19,6 @@ When you create a new guide, you can start with a blank guide, or use a template
 | ------------ | ------------------------------------------------------------------------------------------------------ |
 | Tour         | Guide users to explore your product.                                                                   |
 | Announcement | Tell your users something, like information about a product changes, company updates, or new features. |
-| Checklists <br/> {.tag .web .zero}   | Help your users complete tasks by showing them step-by-step instructions.                              |
+| Checklists <br/> {.tag .web .zero} | Help your users complete tasks by showing them step-by-step instructions.        |
 | Banners      | Highlight important messages or alerts.                                                                |
 | Tooltips     | Provide quick tips or additional context, related to a specific element on screen.                     |


### PR DESCRIPTION
Split out web tag changes from carousel PR: https://github.com/amplitude/amplitude-docs/pull/932