### PR TITLE
Fix formatting and add HTML escaping example in localization docs

### DIFF
--- a/content/collections/guides_and_surveys/en/localization.md
+++ b/content/collections/guides_and_surveys/en/localization.md
@@ -5,7 +5,7 @@ title: Localization
 landing: false
 ---
 
-Localization enables you to serve guides and surveys in different languages without creating a new guide or survey for each language. Supported languages are available on a project basis. 
+Localization enables you to serve guides and surveys in different languages without creating a new guide or survey for each language. Supported languages are available on a project basis.
 
 To create localized versions of your guides and surveys, you must:
 - Update the SDK to record the user's locale.
@@ -46,7 +46,7 @@ Amplitude considers only the language of a locale code. For example, `fr_FR` and
 
 Navigate to *Project Settings > Guides and Surveys*.
 
-From here, you can specify the localiation settings for Guides and Surveys. 
+From here, you can specify the localiation settings for Guides and Surveys.
 
 On this tab, you can:
 
@@ -63,7 +63,7 @@ English is the default language for all projects. This default setting can only 
 ##### To add a supported language
 
 1. In the Supported languages section, click **Add language**.
-2. In the menu, search for or scroll to select the languages you want. 
+2. In the menu, search for or scroll to select the languages you want.
 You can select as many as you want.
 3. Click **Apply**.
 
@@ -72,11 +72,11 @@ You can select as many as you want.
 Fallback behavior is what happens if, for some reason, the localized content is not available. You can specify the following types of fallback behavior:
 
 - **When translation is unavailable**: If a translation for a specific guide or survey hasn't been uploaded, you can specify if you want the content to appear in the default language or if you don't want the content to appear at all.
-- **When translation is outdated**: If the default content is updated, but that update isn't reflected in the translated content, you can specify if you want the content to appear in the default language, the outdated version of the content should appear, or if you don't want the content to appear at all. 
+- **When translation is outdated**: If the default content is updated, but that update isn't reflected in the translated content, you can specify if you want the content to appear in the default language, the outdated version of the content should appear, or if you don't want the content to appear at all.
 
 ## Adding localized content to a guide or survey
 
-You can add localized versions to existing guides or surveys or you can include localized content as you create new guides and surveys. 
+You can add localized versions to existing guides or surveys or you can include localized content as you create new guides and surveys.
 
 ##### To add localized content to a guide or survey
 
@@ -118,19 +118,19 @@ There are a number of ways to add localized content to your guide or survey:
 
 {{partial:tabs tabs="Web interface, AI localization, XLIFF file upload"}}
 {{partial:tab name="Web interface"}}
-The web interface is the most direct method of adding localized content to a guide or survey. The web interface is the preferred way of adding localized content to a guide or survey because it offers a direct relationship to each text string. 
+The web interface is the most direct method of adding localized content to a guide or survey. The web interface is the preferred way of adding localized content to a guide or survey because it offers a direct relationship to each text string.
 
 1. Click the **Build** tab of your guide or survey.
 2. In the upper-right of the screen, click the language toggle.
 By default, this is **English**.
-3. Select the language you want. 
+3. Select the language you want.
 4. Update the individual strings with your translated content.
 All content is automatically associated with the langauge displayed in the language toggle.
 
 
 {{/partial:tab}}
 {{partial:tab name="AI localization"}}
-AI localization automatically translates your guide or survey content using [Claude](https://claude.ai/login?returnTo=%2F%3F). Amplitude takes the strings from the default language and attempts to: 
+AI localization automatically translates your guide or survey content using [Claude](https://claude.ai/login?returnTo=%2F%3F). Amplitude takes the strings from the default language and attempts to:
 
 - Maintain the original meaning and tone.
 - Make the translations natural and user-friendly.
@@ -162,7 +162,10 @@ If you want to integrate with your own translation workflow, you can download an
         </trans-unit>
     ```
     {{/partial:admonition}}
-3. Create translations to your target languages with the template file and upload a translated .xliff file for each language. If you don't upload a file for a language, Guides and Surveys follows the specified fallback setting for a missing translation.
+3. Create translations to your target languages with the template file and upload a translated .xliff file for each language. If you don't upload a file for a language, Guides and Surveys follows the specified fallback setting for a missing translation. If you need to include HTML in your guide or survey content (common for `<br>` tags), make sure to escape the HTML in the `<target>` tag. For example:
+    ```xml
+    <target>First line&lt;br&gt;Second line</target>
+    ```
 4. After you upload an .xliff file, review the content by toggling through the language picker.
 
     {{partial:admonition type="tip" heading="Update translations"}}


### PR DESCRIPTION
This PR fixes formatting issues and adds an HTML escaping example in the localization documentation.

**Changes:**
- Remove trailing whitespace throughout the localization.md file
- Fix line endings
- Add example for HTML escaping in XLIFF file uploads section