### PR TITLE
Add draft for experiment approvals

### DIFF
--- a/content/collections/experiment/en/managing-flags-and-experiments-with-approvals.md
+++ b/content/collections/experiment/en/managing-flags-and-experiments-with-approvals.md
@@ -17,43 +17,46 @@ Improve the governance of your experimentation program and decrease the risk of 
 
 ## Setting up Approvals
 
-You can turn on approvals by going to _Organization Settings > Experiment > Approvals_. Only users with the manager or admin role can modify approvals settings.
+Turn on approvals by going to _Organization Settings > Experiment > Approvals_. 
+
+Only users who have manager or admin roles can modify approvals settings.
 
 Add the individual projects that you would like to require approvals for.
 
-For each project, you have two options: 
-1. Peer approvals: Any users with access can respond to pending approval requests
-2. Specific approvers: Only the users designated will be able to respond to pending approval requests
+For each project, you can specify one of the following options: 
+1. **Peer approvals**: Any users with access can respond to pending approval requests
+2. **Specific approvers**: Only the users designated will be able to respond to pending approval requests
 
 Additionally, admin users will always be able to respond to pending approvals.
 
 ## Requesting and responding to approval requests
 
-### Approvals are required to activate flags and experiments
+### Requiring approvals to activate flags and experiments
 
-Once approvals are enabled for a project: 
+After approvals are enabled for a project, your organization will follow this approvals process: 
+
 1. When starting or scheduling an experiment or activating or scheduling a feature flag, the requestor must select approver(s) to notify.
-2. The experiment will display a “Pending Approval” status until approved.
+2. The experiment displays a “Pending Approval” status until it's approved.
 3. Approvers can review the experiment and either approve the requested changes or reject the changes.
-4. This will notify the original requestor of the response.
+4. The approval or rejection automatically notifies the original requestor of the response.
 
 While the approval is pending, users can make additional changes to the flag or experiment configuration, enter or exit testing mode, or cancel the request at any time.
 
 After the approval is approved for scheduled flags and experiments, users can still modify any configuration until the scheduled start date.
 
-### Approvals are required for critical changes to live flags and experiments
+### Requiring approvals for critical changes to live flags and experiments
 
 When a flag or experiment is active, making some types of changes will also require approval:
 
 | Field    | Type of Change    |
 | --- | --- |
-| Target Segments | Adding and removing segments, modifying conditions or bucketing    |
-| Variants | Any changes, including adding, renaming or removing variants    |
+| Target Segments | Adding and removing segments, modifying conditions or bucketing.    |
+| Variants | Any changes, including adding, renaming or removing variants.    |
 | Variant Distribution | Any changes |
 | Exposure Event | Any changes |
 | Bucketing Salt | Any changes | 
 | Sticky Bucketing | Enabling / Disabling | 
 
-When reviewing these approval requests, users will see the full list of changes in the approval banner.
+When reviewing these approval requests, users can view the full list of changes in the approval banner.
 
 While these approvals are pending, the flag or experiment will also be locked down and users will be unable to make any additional changes until the approval is cancelled or completed.

--- a/content/collections/experiment/en/managing-flags-and-experiments-with-approvals.md
+++ b/content/collections/experiment/en/managing-flags-and-experiments-with-approvals.md
@@ -41,7 +41,7 @@ After approvals are enabled for a project, Amplitude recommends that you follow 
 
 While the approval is pending, users can make additional changes to the flag or experiment configuration, enter or exit testing mode, or cancel the request at any time.
 
-When the scheduled flag or experiment gains approval, users with access can modify any setting until the scheduled start date.
+When the scheduled flag or experiment gains approval, the flag or experiment is considered live and requires approvals for critical changes.
 
 ### Requiring approvals for critical changes to live flags and experiments
 

--- a/content/collections/experiment/en/managing-flags-and-experiments-with-approvals.md
+++ b/content/collections/experiment/en/managing-flags-and-experiments-with-approvals.md
@@ -22,29 +22,30 @@ Only users who have manager or admin roles can modify approvals settings.
 Add the individual projects that you would like to require approvals for.
 
 For each project, you can specify one of the following options: 
-1. **Peer approvals**: Any users with access can respond to pending approval requests
-2. **Specific approvers**: Only the users designated will be able to respond to pending approval requests
 
-Additionally, admin users will always be able to respond to pending approvals.
+1. **Peer approvals**: Any users with access can respond to pending approval requests
+2. **Specific approvers**: Only the users designated can respond to pending approval requests
+
+Additionally, admin users can respond to pending approvals.
 
 ## Requesting and responding to approval requests
 
 ### Requiring approvals to activate flags and experiments
 
-After approvals are enabled for a project, your organization will follow this approvals process: 
+After approvals are enabled for a project, Amplitude recommends that you follow this approval process: 
 
-1. When starting or scheduling an experiment or activating or scheduling a feature flag, the requestor must select approver(s) to notify.
+1. When starting or scheduling an experiment or activating or scheduling a feature flag, the requestor selects one or more approver to notify.
 2. The experiment displays a “Pending Approval” status until it's approved.
 3. Approvers can review the experiment and either approve the requested changes or reject the changes.
 4. The approval or rejection automatically notifies the original requestor of the response.
 
 While the approval is pending, users can make additional changes to the flag or experiment configuration, enter or exit testing mode, or cancel the request at any time.
 
-After the approval is approved for scheduled flags and experiments, users can still modify any configuration until the scheduled start date.
+When the scheduled flag or experiment gains approval, users with access can modify any setting until the scheduled start date.
 
 ### Requiring approvals for critical changes to live flags and experiments
 
-When a flag or experiment is active, making some types of changes will also require approval:
+When a flag or experiment is active, certain updates also require approval:
 
 | Field    | Type of Change    |
 | --- | --- |
@@ -57,4 +58,4 @@ When a flag or experiment is active, making some types of changes will also requ
 
 When reviewing these approval requests, users can view the full list of changes in the approval banner.
 
-While these approvals are pending, the flag or experiment will also be locked down and users will be unable to make any additional changes until the approval is cancelled or completed.
+When approvals are pending, the flag or experiment is locked. This prevents users with access from making other changes until the previous approval request is completed or cancelled.

--- a/content/collections/experiment/en/managing-flags-and-experiments-with-approvals.md
+++ b/content/collections/experiment/en/managing-flags-and-experiments-with-approvals.md
@@ -9,11 +9,9 @@ exclude_from_sitemap: false
 updated_by: e6d8f28f-00c6-426e-9ab9-664028ddc50c
 updated_at: 1758133452
 ---
-{{partial:admonition type='note'}}
-Experiment Approvals is only available to Growth and Enterprise customers.
-{{/partial:admonition}}
-
 Improve the governance of your experimentation program and decrease the risk of unintended changes by requiring approvals for critical changes to experiment configuration.
+
+Experiment Approvals is only available to Growth and Enterprise customers.
 
 ## Setting up Approvals
 

--- a/content/collections/experiment/en/managing-flags-and-experiments-with-approvals.md
+++ b/content/collections/experiment/en/managing-flags-and-experiments-with-approvals.md
@@ -13,7 +13,7 @@ Improve the governance of your experimentation program and decrease the risk of 
 
 Experiment Approvals is only available to Growth and Enterprise customers.
 
-## Setting up Approvals
+## Setting up approvals
 
 Turn on approvals by going to _Organization Settings > Experiment > Approvals_. 
 

--- a/content/collections/experiment/en/managing-flags-and-experiments-with-approvals.md
+++ b/content/collections/experiment/en/managing-flags-and-experiments-with-approvals.md
@@ -1,0 +1,59 @@
+---
+id: c7210fe3-77ed-43ee-9f76-7ad20736c439
+blueprint: experiment
+title: 'Managing flags and experiments with approvals'
+this_article_will_help_you:
+  - 'Learn how to use the approvals workflows for feature flags and experiments'
+landing: false
+exclude_from_sitemap: false
+updated_by: e6d8f28f-00c6-426e-9ab9-664028ddc50c
+updated_at: 1758133452
+---
+{{partial:admonition type='note'}}
+Experiment Approvals is only available to Growth and Enterprise customers.
+{{/partial:admonition}}
+
+Improve the governance of your experimentation program and decrease the risk of unintended changes by requiring approvals for critical changes to experiment configuration.
+
+## Setting up Approvals
+
+You can turn on approvals by going to _Organization Settings > Experiment > Approvals_. Only users with the manager or admin role can modify approvals settings.
+
+Add the individual projects that you would like to require approvals for.
+
+For each project, you have two options: 
+1. Peer approvals: Any users with access can respond to pending approval requests
+2. Specific approvers: Only the users designated will be able to respond to pending approval requests
+
+Additionally, admin users will always be able to respond to pending approvals.
+
+## Requesting and responding to approval requests
+
+### Approvals are required to activate flags and experiments
+
+Once approvals are enabled for a project: 
+1. When starting or scheduling an experiment or activating or scheduling a feature flag, the requestor must select approver(s) to notify.
+2. The experiment will display a “Pending Approval” status until approved.
+3. Approvers can review the experiment and either approve the requested changes or reject the changes.
+4. This will notify the original requestor of the response.
+
+While the approval is pending, users can make additional changes to the flag or experiment configuration, enter or exit testing mode, or cancel the request at any time.
+
+After the approval is approved for scheduled flags and experiments, users can still modify any configuration until the scheduled start date.
+
+### Approvals are required for critical changes to live flags and experiments
+
+When a flag or experiment is active, making some types of changes will also require approval:
+
+| Field    | Type of Change    |
+| --- | --- |
+| Target Segments | Adding and removing segments, modifying conditions or bucketing    |
+| Variants | Any changes, including adding, renaming or removing variants    |
+| Variant Distribution | Any changes |
+| Exposure Event | Any changes |
+| Bucketing Salt | Any changes | 
+| Sticky Bucketing | Enabling / Disabling | 
+
+When reviewing these approval requests, users will see the full list of changes in the approval banner.
+
+While these approvals are pending, the flag or experiment will also be locked down and users will be unable to make any additional changes until the approval is cancelled or completed.

--- a/content/trees/collections/en/experiment.yaml
+++ b/content/trees/collections/en/experiment.yaml
@@ -25,3 +25,5 @@ tree:
     entry: 1dc8fb12-66f4-4ff0-bf73-e2e52fcd78b1
   -
     entry: e39f9287-bec8-4403-ba60-8b04da56b5f9
+  -
+    entry: c7210fe3-77ed-43ee-9f76-7ad20736c439

--- a/content/trees/navigation/en/experiment.yaml
+++ b/content/trees/navigation/en/experiment.yaml
@@ -178,6 +178,9 @@ tree:
             id: e05b14be-4608-493e-9e68-5c56f0003390
             entry: 6b86591a-0640-488d-b94c-5973aea3308b
             title: 'Inflection points and flattened slopes'
+      -
+        id: 61fd8215-d1e2-4541-a890-293103ae7a04
+        entry: c7210fe3-77ed-43ee-9f76-7ad20736c439
   -
     id: e67e82c0-c298-4d72-bd01-6e42a7e97826
     title: Integrations

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -446,6 +446,7 @@
     "/docs/md/experiment/en/index.md": "/docs/md/experiment/en/index.md",
     "/docs/md/experiment/en/key-terms.md": "/docs/md/experiment/en/key-terms.md",
     "/docs/md/experiment/en/local-evaluation.md": "/docs/md/experiment/en/local-evaluation.md",
+    "/docs/md/experiment/en/managing-flags-and-experiments-with-approvals.md": "/docs/md/experiment/en/managing-flags-and-experiments-with-approvals.md",
     "/docs/md/experiment/en/notifications.md": "/docs/md/experiment/en/notifications.md",
     "/docs/md/experiment/en/overview.md": "/docs/md/experiment/en/overview.md",
     "/docs/md/experiment/en/project-level-permissions.md": "/docs/md/experiment/en/project-level-permissions.md",


### PR DESCRIPTION
The new Experiment Approvals feature is going live in the next week and this is intended to be a basic guide for using approvals. 

Please let me know if there are any questions about the feature!