### PR TITLE
FOO-1942 add documentation on proxying images with mediaUrl

### DIFF
--- a/content/collections/guides_and_surveys/en/proxy.md
+++ b/content/collections/guides_and_surveys/en/proxy.md
@@ -53,7 +53,7 @@ This setup uses one CloudFront distribution with three origins and three cache b
 5. Add a third origin for nudge images. Navigate to the _Origins_ tab and click **Create origin**:
 
    - **Origin domain**:
-     - `engagement-static.amplitude.com` for the US data center, or
+     - `engagement-static.amplitude.com` for the US data center
      - `engagement-static.eu.amplitude.com` for the EU data center
 
 6. Navigate to the 'Behaviors' tab and click **Create behavior**:

--- a/content/collections/guides_and_surveys/en/proxy.md
+++ b/content/collections/guides_and_surveys/en/proxy.md
@@ -8,10 +8,11 @@ Set up a single AWS CloudFront distribution to reverse proxy both static assets 
 
 ## Create a unified CloudFront distribution
 
-This setup uses one CloudFront distribution with two origins and two cache behaviors:
+This setup uses one CloudFront distribution with three origins and three cache behaviors:
 
 - The **default origin** proxies `cdn.amplitude.com` or `cdn.eu.amplitude.com` for static SDK assets.
 - A **secondary origin** proxies `gs.amplitude.com` or `gs.eu.amplitude.com` for API requests prefixed with `/sdk/`.
+- A **third origin** proxies `engagement-static.amplitude.com` or `engagement-static.eu.amplitude.com` for nudge images using a wildcard pattern.
 
 ### Step-by-step configuration
 
@@ -26,10 +27,10 @@ This setup uses one CloudFront distribution with two origins and two cache behav
    - **Origin request policy**: `AllViewerExceptHostHeader`
    - **Response headers policy**: `CORS-with-preflight-and-SecurityHeadersPolicy`
    - **Web Application Firewall (WAF)**: Don't enable security protections.
-  
+
    Click **Create distribution**
 
-3. Add a second origin for the Guides and Surveys API. Navigate to the *Origins* tab and click **Create origin**:
+3. Add a second origin for the Guides and Surveys API. Navigate to the _Origins_ tab and click **Create origin**:
 
    - **Origin domain**:
      - `gs.amplitude.com` for the US data center, or
@@ -48,6 +49,22 @@ This setup uses one CloudFront distribution with two origins and two cache behav
    {{partial:admonition type="warning"}}
    Use the wildcard pattern `/sdk/*` exactly as shown. Don't hard code a list of specific paths like `/sdk/config`. The Guides and Surveys SDK makes requests to multiple endpoints under the `/sdk/` path, including `/sdk/admin/config` for preview mode functionality. Using specific paths instead of the wildcard pattern causes some features to fail.
    {{/partial:admonition}}
+
+5. Add a third origin for nudge images. Navigate to the _Origins_ tab and click **Create origin**:
+
+   - **Origin domain**:
+     - `engagement-static.amplitude.com` for the US data center, or
+     - `engagement-static.eu.amplitude.com` for the EU data center
+
+6. Navigate to the 'Behaviors' tab and click **Create behavior**:
+
+   - **Path pattern**: `*`
+   - **Origin**: Select `engagement-static.amplitude.com` or `engagement-static.eu.amplitude.com`
+   - **Allowed HTTP methods**: `GET, HEAD, OPTIONS`
+     - **Cache HTTP methods**: `OPTIONS`
+   - **Cache policy**: Choose a suitable caching policy for static assets (for example, `CachingOptimized`)
+   - **Origin request policy**: `AllViewerExceptHostHeader`
+   - **Response headers policy**: `CORS-with-preflight-and-SecurityHeadersPolicy`
 
 ## Test the proxy
 
@@ -73,27 +90,31 @@ A successful response returns HTTP status `200 OK`.
 
 ## Initialize the SDK with the proxy
 
-Point both `serverUrl` and `cdnUrl` to the same CloudFront domain:
+Point `serverUrl`, `cdnUrl`, and `mediaUrl` to the same CloudFront domain:
 
 ```js
 engagement.init("API_KEY", {
   serverUrl: "https://SUBDOMAIN.cloudfront.net",
-  cdnUrl: "https://SUBDOMAIN.cloudfront.net"
+  cdnUrl: "https://SUBDOMAIN.cloudfront.net",
+  mediaUrl: "https://SUBDOMAIN.cloudfront.net",
 });
 ```
 
+The `mediaUrl` parameter ensures that images used in nudges are also proxied through your CloudFront distribution. This prevents images from failing to load when customer domains block requests to `engagement-static.amplitude.com`.
+
 ## Troubleshooting common proxy issues
 
-| Issue                                              | Symptoms                                                                    | Cause                                                                                                        | Solution                                                                                                                                                                                                                                      |
-| -------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Preview mode doesn't work                          | Preview mode fails to load or display guides properly                       | Path pattern configured with specific paths instead of wildcard pattern `/sdk/*` (for example, using `/sdk/config`) | Set the path pattern to `/sdk/*` exactly as specified in step 4. Preview mode makes requests to `/sdk/admin/config`, which won't be proxied with specific paths.                                                                    |
-| Guides don't persist dismissal or completion state | Guides reappear on the next session even after the user dismisses or completes them. | Cause 1: Allowed HTTP methods don't include `POST`, which Guides and Surveys requires for state updates.<br>Cause 2: the origin request policy isn't `AllViewerExceptHostHeader`                               | Solution 1: Verify that allowed HTTP methods in step 4 include `POST` along with other required methods: `GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE`. Without POST, the SDK can't send requests to the `/state` endpoint to update user interaction state.<br>Solution 2: Ensure the origin request policy is `AllViewerExceptHostHeader`. `POST` requests will fail if the host header is overridden with an invalid value. |
+| Issue                                              | Symptoms                                                                             | Cause                                                                                                                                                                                    | Solution                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Preview mode doesn't work                          | Preview mode fails to load or display guides properly                                | Path pattern configured with specific paths instead of wildcard pattern `/sdk/*` (for example, using `/sdk/config`)                                                                      | Set the path pattern to `/sdk/*` exactly as specified in step 4. Preview mode makes requests to `/sdk/admin/config`, which won't be proxied with specific paths.                                                                                                                                                                                                                                                                |
+| Guides don't persist dismissal or completion state | Guides reappear on the next session even after the user dismisses or completes them. | Cause 1: Allowed HTTP methods don't include `POST`, which Guides and Surveys requires for state updates.<br>Cause 2: the origin request policy isn't `AllViewerExceptHostHeader`         | Solution 1: Verify that allowed HTTP methods in step 4 include `POST` along with other required methods: `GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE`. Without POST, the SDK can't send requests to the `/state` endpoint to update user interaction state.<br>Solution 2: Ensure the origin request policy is `AllViewerExceptHostHeader`. `POST` requests will fail if the host header is overridden with an invalid value. |
+| Images don't load in nudges                        | Images in guides appear as broken or missing, showing placeholder icons instead      | Cause 1: `mediaUrl` parameter not configured in SDK initialization.<br>Cause 2: Missing wildcard `*` cache behavior for image origin.<br>Cause 3: Image origin not configured correctly. | Solution 1: Add `mediaUrl: "https://SUBDOMAIN.cloudfront.net"` to your SDK initialization.<br>Solution 2: Ensure you've created a wildcard `*` cache behavior pointing to the `engagement-static.amplitude.com` or `engagement-static.eu.amplitude.com` origin.<br>Solution 3: Verify the image origin domain matches your data center (US vs EU).                                                                              |
 
 ### General debugging steps
 
 1. **Check CloudFront logs**: Enable logging on your CloudFront distribution to see which requests are being made and their response codes.
 
-2. **Verify both origins are configured**: Ensure you have both the CDN origin (`cdn.amplitude.com` or `cdn.eu.amplitude.com`) and the API origin (`gs.amplitude.com` or `gs.eu.amplitude.com`).
+2. **Verify all three origins are configured**: Ensure you have the CDN origin (`cdn.amplitude.com` or `cdn.eu.amplitude.com`), the API origin (`gs.amplitude.com` or `gs.eu.amplitude.com`), and the image origin (`engagement-static.amplitude.com` or `engagement-static.eu.amplitude.com`).
 
 3. **Test both endpoints**: Use the curl commands in the "Test the proxy" section to verify both the API and CDN paths are working correctly.
 

--- a/content/collections/guides_and_surveys/en/sdk.md
+++ b/content/collections/guides_and_surveys/en/sdk.md
@@ -60,22 +60,23 @@ But, instead of calling `amplitude.add(window.engagement.plugin())`, you need to
 
 #### Initialize the SDK
 
-Call `init` to  fully initialize the bundle and register `engagement` on the global window object.
+Call `init` to fully initialize the bundle and register `engagement` on the global window object.
 
 ```js
-engagement.init(apiKey: string, options: { serverZone: "US" | "EU", serverUrl: string, cdnUrl: string, logger: Logger, logLevel: LogLevel, locale: string, nonce: string }): void
+engagement.init(apiKey: string, options: { serverZone: "US" | "EU", serverUrl: string, cdnUrl: string, mediaUrl: string, logger: Logger, logLevel: LogLevel, locale: string, nonce: string }): void
 ```
 
-| Parameter                | Type                                                                                                                         | Description                                                                                                                                                                                    |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `apiKey`                 | `string`                                                                                                                     | Required. API key of the Amplitude project you want to use.                                                                                                                                    |
-| `initOptions.serverZone` | `EU` or `US`                                                                                                                 | Optional. Sets the Amplitude server zone. Set this to EU for Amplitude projects created in EU data center. Default: `US`                                                                       |
-| `initOptions.serverUrl`  | `string`                                                                                                                     | Optional. Sets a custom server URL for API requests. Useful for [proxy setups](/docs/guides-and-surveys/proxy). Default: `https://gs.amplitude.com` (US) or `https://gs.eu.amplitude.com` (EU) |
-| `initOptions.cdnUrl`     | `string`                                                                                                                     | Optional. Sets a custom CDN URL for static assets. Useful for [proxy setups](/docs/guides-and-surveys/proxy). Default: `https://cdn.amplitude.com` (US) or `https://cdn.eu.amplitude.com` (EU) |
-| `initOptions.logger`     | [Logger interface](https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-types/src/logger.ts#L1-L8) | Optional. Sets a custom logging provider class. Default: [Amplitude Logger](https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-core/src/logger.ts)                 |
-| `initOptions.logLevel`   | `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`.                            | Optional. Sets the log level. Default: `LogLevel.Warn`                                                                                                                                         |
-| `initOptions.locale`     | `string`                                                                                                                     | Optional. Sets the locale for [localization](/docs/guides-and-surveys/sdk#localization). Default: `undefined`. Not setting a language means the default language is used.                      |
-| `initOptions.nonce`      | `string`                                                                                                                     | Optional. Sets a nonce value for Content Security Policy (CSP) compliance. This allows inline styles required by Guides and Surveys to be executed when CSP is enabled. Default: `undefined`   |
+| Parameter                | Type                                                                                                                         | Description                                                                                                                                                                                                                                            |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `apiKey`                 | `string`                                                                                                                     | Required. API key of the Amplitude project you want to use.                                                                                                                                                                                            |
+| `initOptions.serverZone` | `EU` or `US`                                                                                                                 | Optional. Sets the Amplitude server zone. Set this to EU for Amplitude projects created in EU data center. Default: `US`                                                                                                                               |
+| `initOptions.serverUrl`  | `string`                                                                                                                     | Optional. Sets a custom server URL for API requests. Useful for [proxy setups](/docs/guides-and-surveys/proxy). Default: `https://gs.amplitude.com` (US) or `https://gs.eu.amplitude.com` (EU)                                                         |
+| `initOptions.cdnUrl`     | `string`                                                                                                                     | Optional. Sets a custom CDN URL for static assets. Useful for [proxy setups](/docs/guides-and-surveys/proxy). Default: `https://cdn.amplitude.com` (US) or `https://cdn.eu.amplitude.com` (EU)                                                         |
+| `initOptions.mediaUrl`   | `string`                                                                                                                     | Optional. Sets a custom URL for proxying nudge images. Useful for [proxy setups](/docs/guides-and-surveys/proxy) when images are blocked. Default: `https://engagement-static.amplitude.com` (US) or `https://engagement-static.eu.amplitude.com` (EU) |
+| `initOptions.logger`     | [Logger interface](https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-types/src/logger.ts#L1-L8) | Optional. Sets a custom logging provider class. Default: [Amplitude Logger](https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-core/src/logger.ts)                                                                         |
+| `initOptions.logLevel`   | `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`.                            | Optional. Sets the log level. Default: `LogLevel.Warn`                                                                                                                                                                                                 |
+| `initOptions.locale`     | `string`                                                                                                                     | Optional. Sets the locale for [localization](/docs/guides-and-surveys/sdk#localization). Default: `undefined`. Not setting a language means the default language is used.                                                                              |
+| `initOptions.nonce`      | `string`                                                                                                                     | Optional. Sets a nonce value for Content Security Policy (CSP) compliance. This allows inline styles required by Guides and Surveys to be executed when CSP is enabled. Default: `undefined`                                                           |
 
 ##### Example: Basic initialization
 
@@ -88,12 +89,13 @@ engagement.init("YOUR_API_KEY", {
 
 ##### Example: Initialization with proxy
 
-For [proxy setups](/docs/guides-and-surveys/proxy), specify both `serverUrl` and `cdnUrl`:
+For [proxy setups](/docs/guides-and-surveys/proxy), specify `serverUrl`, `cdnUrl`, and `mediaUrl`:
 
 ```js
 engagement.init("YOUR_API_KEY", {
   serverUrl: "https://your-proxy-domain.cloudfront.net",
-  cdnUrl: "https://your-proxy-domain.cloudfront.net"
+  cdnUrl: "https://your-proxy-domain.cloudfront.net",
+  mediaUrl: "https://your-proxy-domain.cloudfront.net",
 });
 ```
 


### PR DESCRIPTION
## Why

This change documents the new mediaUrl initialization parameter that enables proxying of guides and surveys images.
Previously, customers using proxy setups would encounter broken images in guides because images were still loading directly from engagement-static.amplitude.com, which could be blocked by corporate firewalls or content security policies.
